### PR TITLE
feat(examples/ecommerce): add document description in user context

### DIFF
--- a/examples/ecommerce/app/src/app/api/chat/route.ts
+++ b/examples/ecommerce/app/src/app/api/chat/route.ts
@@ -43,6 +43,7 @@ const getSystemPrompt = (props: {userContext: UserContext}) => {
 
     <user-context>
       <document-title>${userContext.documentTitle}</document-title>
+      <document-description>${userContext.documentDescription}</document-description>
       <document-location>${userContext.documentLocation}</document-location>
     </user-context>
 

--- a/examples/ecommerce/app/src/lib/capture-context.ts
+++ b/examples/ecommerce/app/src/lib/capture-context.ts
@@ -18,8 +18,13 @@ export const AGENT_CHAT_HIDDEN_ATTRIBUTE = 'agent-chat-hidden'
  * This is sent with every message so the agent knows where the user is.
  */
 export function captureUserContext(): UserContext {
+  const metaDescription =
+    document.querySelector('meta[name="description"]')?.getAttribute('content') ||
+    document.querySelector('meta[property="og:description"]')?.getAttribute('content')
+
   return {
     documentTitle: document.title,
+    documentDescription: metaDescription || undefined,
     documentLocation: window.location.pathname,
   }
 }

--- a/examples/ecommerce/app/src/lib/client-tools.ts
+++ b/examples/ecommerce/app/src/lib/client-tools.ts
@@ -6,6 +6,7 @@
 /** User context sent with every message so the agent knows where the user is. */
 export interface UserContext {
   documentTitle: string
+  documentDescription?: string
   documentLocation: string
 }
 


### PR DESCRIPTION
### Description

This pull request adds `<document-description />` to the user context in the e-commerce example.
