### PR TITLE
feat(examples/ecommerce): document directives

### DIFF
--- a/examples/ecommerce/app/src/app/api/chat/route.ts
+++ b/examples/ecommerce/app/src/app/api/chat/route.ts
@@ -54,23 +54,16 @@ const getSystemPrompt = (props: {userContext: UserContext}) => {
     -  Use for: "Does this look right?", "What color is X?", "Show me what you see"
     - Only when you need to SEE images, colors, or layout.
 
-    # Tools
-    - **get_page_context** - Page text as markdown. Use before screenshot when visuals aren't needed.
-    - **get_page_screenshot** - Visual screenshot. Only when you need to see images/colors/layout.
-
-    ## GROQ tips
-    - Dereference references: use \`field->\` syntax (e.g., \`asset->url\`)
-    - For images: \`image.asset->url\` to get the URL
-
     # Displaying products
-    - ALWAYS use product directives. NEVER write product names as plain text.
-    - To mention specific products, you MUST query Sanity first to get slug, title, and image.
-    - If you don't have all three values (slug, title, image), describe products generically (e.g., "8 featured products") instead of listing names.
-    - Page context may contain product names - do NOT repeat these as plain text. Either query Sanity for full details or summarize generically.
+    - ALWAYS use document directives. NEVER write product names as plain text.
+    - Query Sanity to get document _id and _type, then use the directive syntax below.
+    - Page context may contain product names - do NOT repeat these as plain text. Query Sanity for the _id or summarize generically.
 
     ## Directive syntax
-    ::product{slug="..." title="..." image="..."}  <- Block format (for lists)
-    :product{slug="..." title="..."}               <- Inline format (within sentences)
+    ::document{id="<_id>" type="<_type>"}  <- Block format (for lists)
+    :document{id="<_id>" type="<_type>"}   <- Inline format (within sentences)
+
+    Example: ::document{id="product-abc123" type="product"}
 `
 }
 

--- a/examples/ecommerce/app/src/components/chat/message/Document.tsx
+++ b/examples/ecommerce/app/src/components/chat/message/Document.tsx
@@ -1,0 +1,26 @@
+import {Product} from './Product'
+
+export interface DocumentProps {
+  id: string
+  type: string
+  isInline?: boolean
+}
+
+/**
+ * Routes document directives to type-specific components.
+ *
+ * Flow: AI outputs directive → remarkDirectives parses → this component routes by type
+ *
+ * Directive syntax (defined in route.ts system prompt):
+ *   ::document{id="<_id>" type="<_type>"}  - Block (cards in lists)
+ *   :document{id="<_id>" type="<_type>"}   - Inline (links in sentences)
+ *
+ * To add a new type: add a case here and create the component (see Product.tsx).
+ */
+export function Document(props: DocumentProps) {
+  if (props.type === 'product') {
+    return <Product {...props} />
+  }
+
+  return null
+}

--- a/examples/ecommerce/app/src/components/chat/message/Product.tsx
+++ b/examples/ecommerce/app/src/components/chat/message/Product.tsx
@@ -1,36 +1,78 @@
+'use client'
+
 import Image from 'next/image'
 import Link from 'next/link'
+import {useEffect, useState} from 'react'
 
-interface ProductProps {
-  slug?: string
-  title?: string
-  image?: string
-  isInline?: boolean
+import {client} from '@/sanity/lib/client'
+import {urlFor} from '@/sanity/lib/image'
+
+import type {DocumentProps} from './Document'
+
+interface ProductData {
+  slug: string
+  title: string
+  image: {asset: {_ref: string}} | null
 }
 
-export function Product(props: ProductProps) {
-  const {slug, title, image, isInline} = props
+const getProduct = async (id: string): Promise<ProductData | null> => {
+  const product = await client.fetch(
+    `*[_type == "product" && _id == $id][0] {
+      title,
+      "slug": slug.current,
+      "image": variants[0].images[0],
+    }
+  `,
+    {id},
+  )
 
-  if (!slug || !title) return null
+  return product
+}
+
+export function Product(props: DocumentProps) {
+  const {isInline} = props
+
+  const [product, setProduct] = useState<ProductData | null>(null)
+
+  useEffect(() => {
+    const fetchProduct = async () => {
+      const product = await getProduct(props.id)
+
+      setProduct(product)
+    }
+    fetchProduct()
+  }, [props.id])
+
+  if (!product) return null
 
   if (isInline) {
     return (
-      <Link href={`/products/${slug}`} className="text-blue-600 underline hover:text-blue-700">
-        {title}
+      <Link
+        href={`/products/${product.slug}`}
+        className="text-blue-600 underline hover:text-blue-700"
+      >
+        {product.title}
       </Link>
     )
   }
 
   return (
     <Link
-      href={`/products/${slug}`}
+      href={`/products/${product.slug}`}
       className="flex items-center gap-3 rounded-md border border-neutral-200 bg-white p-2 transition-colors hover:border-neutral-300 hover:bg-neutral-50"
     >
       <div className="relative h-10 w-10 shrink-0 overflow-hidden rounded bg-neutral-100">
-        {image && <Image src={image} alt={title} fill className="object-cover" />}
+        {product.image && (
+          <Image
+            src={urlFor(product.image).width(80).height(80).url()}
+            alt={product.title}
+            fill
+            className="object-cover"
+          />
+        )}
       </div>
 
-      <span className="text-sm font-medium text-neutral-900">{title}</span>
+      <span className="text-sm font-medium text-neutral-900">{product.title}</span>
     </Link>
   )
 }

--- a/examples/ecommerce/app/src/components/chat/message/TextPart.tsx
+++ b/examples/ecommerce/app/src/components/chat/message/TextPart.tsx
@@ -4,7 +4,7 @@ import remarkDirective from 'remark-directive'
 
 import {cn} from '@/lib/utils'
 
-import {Product} from './Product'
+import {Document} from './Document'
 import {remarkDirectives} from './remarkDirectives'
 
 interface TextPartProps {
@@ -13,14 +13,14 @@ interface TextPartProps {
 }
 
 type ExtendedComponents = Components & {
-  Product: typeof Product
+  Document: typeof Document
 }
 
 export function TextPart({text, isUser}: TextPartProps) {
   if (!text.trim()) return null
 
   const components: ExtendedComponents = {
-    Product,
+    Document,
 
     a(props) {
       const {href = '', children} = props


### PR DESCRIPTION
### Description

This pull request improves the way products are rendered in the response using a new `::document` directive which routes to the appropriate component based on the `type`. The `Product` component now uses `urlFor()` to fetch optimized thumbnails instead of full-size images. 