### PR TITLE
fix(skills): update URL for context MCP

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,7 +99,7 @@ The filter UI provides two modes:
 Each agent context document generates an MCP URL:
 
 ```
-https://context-mcp.sanity.io/mcp/:projectId/:dataset/:slug
+https://api.sanity.io/:apiVersion/agent-context/:projectId/:dataset/:slug
 ```
 
 Agents connect via HTTP transport with a Bearer token (Sanity API read token).

--- a/skills/create-agent-with-sanity-context/SKILL.md
+++ b/skills/create-agent-with-sanity-context/SKILL.md
@@ -38,8 +38,8 @@ An MCP server that gives AI agents structured access to Sanity content. The core
 
 **MCP URL formats:**
 
-- `https://context-mcp.sanity.io/mcp/:projectId/:dataset` — Access all content in the dataset
-- `https://context-mcp.sanity.io/mcp/:projectId/:dataset/:slug` — Access filtered content (requires agent context document with that slug)
+- `https://api.sanity.io/:apiVersion/agent-context/:projectId/:dataset` — Access all content in the dataset
+- `https://api.sanity.io/:apiVersion/agent-context/:projectId/:dataset/:slug` — Access filtered content (requires agent context document with that slug)
 
 The slug-based URL uses the GROQ filter defined in your agent context document to scope what content the agent can access. Use this for production agents that should only see specific content types.
 
@@ -88,7 +88,7 @@ The reference patterns use Next.js + Vercel AI SDK, but adapt to whatever the us
 Before building an agent, you can validate MCP access directly using the base URL (no slug required):
 
 ```bash
-curl -X POST https://context-mcp.sanity.io/mcp/YOUR_PROJECT_ID/YOUR_DATASET \
+curl -X POST https://api.sanity.io/YOUR_API_VERSION/agent-context/YOUR_PROJECT_ID/YOUR_DATASET \
   -H "Authorization: Bearer $SANITY_API_READ_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc": "2.0", "method": "tools/list", "id": 1}'

--- a/skills/create-agent-with-sanity-context/references/nextjs-agent.md
+++ b/skills/create-agent-with-sanity-context/references/nextjs-agent.md
@@ -8,7 +8,7 @@ This is a reference implementation using Next.js and Vercel AI SDK. Use it as a 
 
 These patterns transfer regardless of framework:
 
-1. **MCP Connection**: HTTP transport to `https://context-mcp.sanity.io/mcp/:projectId/:dataset/:slug`
+1. **MCP Connection**: HTTP transport to `https://api.sanity.io/:apiVersion/agent-context/:projectId/:dataset/:slug`
 2. **Authentication**: Bearer token using Sanity API read token
 3. **Tool Discovery**: Get available tools from MCP client, pass to LLM
 4. **System Prompt**: Domain-specific instructions that shape agent behavior
@@ -43,7 +43,7 @@ NEXT_PUBLIC_SANITY_DATASET=production
 SANITY_API_READ_TOKEN=your-read-token
 
 # Context MCP URL (from your Agent Context document)
-SANITY_CONTEXT_MCP_URL=https://context-mcp.sanity.io/mcp/your-project-id/production/your-slug
+SANITY_CONTEXT_MCP_URL=https://api.sanity.io/:apiVersion/agent-context/your-project-id/production/your-slug
 
 # Anthropic API key
 ANTHROPIC_API_KEY=your-anthropic-key

--- a/skills/create-agent-with-sanity-context/references/studio-setup.md
+++ b/skills/create-agent-with-sanity-context/references/studio-setup.md
@@ -94,7 +94,7 @@ The filter UI provides two modes:
 Once your Agent Context document has a slug, the MCP URL appears at the top of the document form:
 
 ```
-https://context-mcp.sanity.io/mcp/:projectId/:dataset/:slug
+https://api.sanity.io/:apiVersion/agent-context/:projectId/:dataset/:slug
 ```
 
 Copy this URL—you'll need it when configuring your agent.


### PR DESCRIPTION
### Description

This pull request updates the Context MCP URL in skills with the new URL.

```diff
- https://context-mcp.sanity.io/mcp/:projectId/:dataset/:slug
+ https://api.sanity.io/:apiVersion/agent-context/:projectId/:dataset/:slug
```