### PR TITLE
feat(agent-context): add prefix option for agent context document IDs

### DIFF
--- a/packages/agent-context/README.md
+++ b/packages/agent-context/README.md
@@ -49,3 +49,51 @@ export default defineConfig({
   ],
 })
 ```
+
+## Private Document IDs
+
+Agent context documents are created with a `sanity.agentContext.` ID prefix (e.g., `sanity.agentContext.abc123`). The `.` in the ID makes the document private — it will not appear in public API queries on public datasets. This is important because agent context documents may contain sensitive AI instructions.
+
+The plugin automatically enforces the prefix for documents created through the Studio's standard creation flows:
+
+- **Pane header "+" button** — sets `initialDocumentId` with prefix
+- **Global "+" menu** — hidden (the global menu does not support custom IDs)
+- **Duplicate action** — replaced with a custom action that generates prefixed IDs
+
+### Custom prefix
+
+The default prefix is `sanity.agentContext`. You can change it by passing `documentIdPrefix` to the plugin. A `.` separator is automatically added between the prefix and the UUID:
+
+```ts
+agentContextPlugin({documentIdPrefix: 'myPrefix'})
+// Documents will have IDs like: myPrefix.abc123...
+```
+
+### Creating documents outside Studio
+
+The plugin cannot enforce the prefix when documents are created outside of Studio. If you create `sanity.agentContext` documents via the Sanity Client or HTTP API, you **must** include the prefix in the document ID yourself:
+
+```ts
+import {uuid} from '@sanity/uuid'
+
+// Correct — document will be private
+client.create({
+  _id: `sanity.agentContext.${uuid()}`,
+  _type: 'sanity.agentContext',
+  // ...
+})
+
+// Wrong — document will be publicly queryable
+client.create({
+  _type: 'sanity.agentContext',
+  // ...
+})
+```
+
+Similarly, if you construct a Studio URL to create a document via intent navigation, include the `id` parameter:
+
+```
+/intent/create/template=sanity.agentContext;type=sanity.agentContext;id=sanity.agentContext.<uuid>
+```
+
+Without the `id` parameter, Studio will generate a plain UUID without the privacy prefix.

--- a/packages/agent-context/package.json
+++ b/packages/agent-context/package.json
@@ -56,6 +56,7 @@
     "@repo/eslint-config": "workspace:*",
     "@sanity/icons": "^3",
     "@sanity/pkg-utils": "^10.3.2",
+    "@sanity/uuid": "^3.0.2",
     "@sanity/tsconfig": "^2.1.0",
     "@sanity/ui": "^3",
     "@types/react": "^19",
@@ -63,6 +64,7 @@
     "@vitest/coverage-v8": "^4.0.0",
     "react": "^19",
     "react-dom": "^19",
+    "rxjs": "^7",
     "sanity": "^5.8.0",
     "styled-components": "^6.3.8",
     "typescript": "^5",
@@ -71,8 +73,10 @@
   "peerDependencies": {
     "@sanity/icons": "^3",
     "@sanity/ui": "^3",
+    "@sanity/uuid": "^3",
     "react": "^19",
     "react-dom": "^19",
+    "rxjs": "^7",
     "sanity": "^5.8.0",
     "styled-components": "^6"
   },

--- a/packages/agent-context/src/studio/agent-context-plugin/actions/AgentContextDuplicateAction.test.ts
+++ b/packages/agent-context/src/studio/agent-context-plugin/actions/AgentContextDuplicateAction.test.ts
@@ -1,0 +1,32 @@
+import {describe, expect, it} from 'vitest'
+
+import {createAgentContextDuplicateAction} from './AgentContextDuplicateAction'
+
+describe('createAgentContextDuplicateAction', () => {
+  it('should create a duplicate action component', () => {
+    const action = createAgentContextDuplicateAction('context')
+    expect(action).toBeDefined()
+    expect(typeof action).toBe('function')
+  })
+
+  it('should set the action property to "duplicate"', () => {
+    const action = createAgentContextDuplicateAction('context')
+    expect(action.action).toBe('duplicate')
+  })
+
+  it('should set the displayName to "AgentContextDuplicateAction"', () => {
+    const action = createAgentContextDuplicateAction('context')
+    expect(action.displayName).toBe('AgentContextDuplicateAction')
+  })
+
+  it('should work with different prefixes', () => {
+    const action1 = createAgentContextDuplicateAction('context')
+    const action2 = createAgentContextDuplicateAction('private')
+    const action3 = createAgentContextDuplicateAction('agent')
+
+    // All should be valid action components
+    expect(action1.action).toBe('duplicate')
+    expect(action2.action).toBe('duplicate')
+    expect(action3.action).toBe('duplicate')
+  })
+})

--- a/packages/agent-context/src/studio/agent-context-plugin/actions/AgentContextDuplicateAction.tsx
+++ b/packages/agent-context/src/studio/agent-context-plugin/actions/AgentContextDuplicateAction.tsx
@@ -1,0 +1,109 @@
+import {CopyIcon} from '@sanity/icons'
+import {uuid} from '@sanity/uuid'
+import {useCallback, useMemo, useTransition} from 'react'
+import {filter, firstValueFrom} from 'rxjs'
+import {
+  type DocumentActionComponent,
+  type DocumentActionProps,
+  getVersionFromId,
+  InsufficientPermissionsMessage,
+  useCurrentUser,
+  useDocumentOperation,
+  useDocumentPairPermissions,
+  useDocumentStore,
+  useTranslation,
+} from 'sanity'
+import {useRouter} from 'sanity/router'
+
+const DISABLED_REASON_KEY = {
+  NOTHING_TO_DUPLICATE: 'action.duplicate.disabled.nothing-to-duplicate',
+  NOT_READY: 'action.duplicate.disabled.not-ready',
+} as const
+
+/**
+ * Creates a duplicate action that generates document IDs with an optional prefix.
+ * Mirrors the core DuplicateAction behavior (permissions, i18n, async navigation)
+ * but prefixes the generated ID when a prefix is provided.
+ *
+ * @param prefix - The prefix to add to document IDs, or null to disable prefixing
+ * @internal
+ */
+export function createAgentContextDuplicateAction(prefix: string | null): DocumentActionComponent {
+  const AgentContextDuplicateAction: DocumentActionComponent = (props: DocumentActionProps) => {
+    const {id, type, version, release} = props
+    const documentStore = useDocumentStore()
+    const bundleId = version?._id && getVersionFromId(version._id)
+
+    const {duplicate} = useDocumentOperation(id, type, bundleId)
+    const {navigateIntent} = useRouter()
+    const [isDuplicating, startDuplicating] = useTransition()
+
+    const [permissions, isPermissionsLoading] = useDocumentPairPermissions({
+      id,
+      type,
+      version: release,
+      permission: 'duplicate',
+    })
+
+    const {t} = useTranslation('structure')
+
+    const currentUser = useCurrentUser()
+
+    const handle = useCallback(() => {
+      startDuplicating(async () => {
+        const dupeId = prefix === null ? uuid() : `${prefix}.${uuid()}`
+
+        const duplicateSuccess = firstValueFrom(
+          documentStore.pair
+            .operationEvents(id, type)
+            .pipe(
+              filter(
+                (e: {op: string; type: string}) => e.op === 'duplicate' && e.type === 'success',
+              ),
+            ),
+        )
+        duplicate.execute(dupeId)
+
+        await duplicateSuccess
+        navigateIntent('edit', {id: dupeId, type})
+      })
+    }, [documentStore.pair, duplicate, id, navigateIntent, startDuplicating, type])
+
+    return useMemo(() => {
+      if (!isPermissionsLoading && !permissions?.granted) {
+        return {
+          icon: CopyIcon,
+          disabled: true,
+          label: t('action.duplicate.label'),
+          title: (
+            <InsufficientPermissionsMessage
+              context="duplicate-document"
+              currentUser={currentUser}
+            />
+          ),
+        }
+      }
+
+      return {
+        icon: CopyIcon,
+        disabled: isDuplicating || Boolean(duplicate.disabled) || isPermissionsLoading,
+        label: isDuplicating ? t('action.duplicate.running.label') : t('action.duplicate.label'),
+        title: duplicate.disabled ? t(DISABLED_REASON_KEY[duplicate.disabled]) : '',
+        onHandle: handle,
+      }
+    }, [
+      currentUser,
+      duplicate.disabled,
+      handle,
+      isDuplicating,
+      isPermissionsLoading,
+      permissions?.granted,
+      t,
+    ])
+  }
+
+  AgentContextDuplicateAction.action = 'duplicate'
+  AgentContextDuplicateAction.displayName = 'AgentContextDuplicateAction'
+
+  return AgentContextDuplicateAction
+}

--- a/packages/agent-context/src/studio/agent-context-plugin/actions/index.ts
+++ b/packages/agent-context/src/studio/agent-context-plugin/actions/index.ts
@@ -1,0 +1,1 @@
+export {createAgentContextDuplicateAction} from './AgentContextDuplicateAction'

--- a/packages/agent-context/src/studio/agent-context-plugin/plugin.test.ts
+++ b/packages/agent-context/src/studio/agent-context-plugin/plugin.test.ts
@@ -1,0 +1,282 @@
+import {describe, expect, it, vi} from 'vitest'
+
+import {AGENT_CONTEXT_SCHEMA_TYPE_NAME} from './agentContextSchema'
+import {AGENT_CONTEXT_DEFAULT_DOCUMENT_ID_PREFIX, agentContextPlugin} from './plugin'
+
+// Mock @sanity/uuid to return predictable values
+vi.mock('@sanity/uuid', () => ({
+  uuid: () => 'test-uuid-12345',
+}))
+
+describe('agentContextPlugin', () => {
+  it('should have the correct plugin name', () => {
+    const plugin = agentContextPlugin()
+    expect(plugin.name).toBe('sanity/agent-context/plugin')
+  })
+
+  it('should register the agent context schema type', () => {
+    const plugin = agentContextPlugin()
+    const types = plugin.schema?.types as {name: string}[] | undefined
+    expect(types).toHaveLength(1)
+    expect(types?.[0]).toHaveProperty('name', AGENT_CONTEXT_SCHEMA_TYPE_NAME)
+  })
+
+  describe('schema templates', () => {
+    it('should add agent context template to the list', () => {
+      const plugin = agentContextPlugin()
+      const templateResolver = plugin.schema?.templates as
+        | ((prev: {id: string}[]) => {id: string}[])
+        | undefined
+      const prevTemplates = [{id: 'other-template', schemaType: 'other', title: 'Other', value: {}}]
+
+      const templates = templateResolver?.(prevTemplates)
+
+      expect(templates).toHaveLength(2)
+      expect(templates?.[0]?.id).toBe('other-template')
+      expect(templates?.[1]?.id).toBe(AGENT_CONTEXT_SCHEMA_TYPE_NAME)
+    })
+  })
+
+  describe('newDocumentOptions', () => {
+    type MockTemplateItem = {
+      templateId: string
+      id: string
+      type: 'initialValueTemplateItem'
+      schemaType: string
+      initialDocumentId?: string
+    }
+
+    const createMockTemplateItem = (templateId: string): MockTemplateItem => ({
+      templateId,
+      id: templateId,
+      type: 'initialValueTemplateItem' as const,
+      schemaType: templateId,
+    })
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const callResolver = (resolver: any, prevItems: MockTemplateItem[], creationContext: any) => {
+      return resolver?.(prevItems, {creationContext}) as MockTemplateItem[] | undefined
+    }
+
+    it('should filter out agent context from global creation context', () => {
+      const plugin = agentContextPlugin()
+      const resolver = plugin.document?.newDocumentOptions
+
+      const prevItems = [
+        createMockTemplateItem('article'),
+        createMockTemplateItem(AGENT_CONTEXT_SCHEMA_TYPE_NAME),
+        createMockTemplateItem('product'),
+      ]
+
+      const result = callResolver(resolver, prevItems, {type: 'global'})
+
+      expect(result).toHaveLength(2)
+      expect(result?.map((item) => item.templateId)).toEqual(['article', 'product'])
+    })
+
+    it('should add prefixed initialDocumentId for structure creation context', () => {
+      const plugin = agentContextPlugin()
+      const resolver = plugin.document?.newDocumentOptions
+
+      const prevItems = [
+        createMockTemplateItem('article'),
+        createMockTemplateItem(AGENT_CONTEXT_SCHEMA_TYPE_NAME),
+      ]
+
+      const result = callResolver(resolver, prevItems, {
+        type: 'structure',
+        schemaType: AGENT_CONTEXT_SCHEMA_TYPE_NAME,
+      })
+
+      expect(result).toHaveLength(2)
+
+      const articleItem = result?.find((item) => item.templateId === 'article')
+      expect(articleItem).not.toHaveProperty('initialDocumentId')
+
+      const agentContextItem = result?.find(
+        (item) => item.templateId === AGENT_CONTEXT_SCHEMA_TYPE_NAME,
+      )
+      expect(agentContextItem?.initialDocumentId).toBe('sanity.agentContext.test-uuid-12345')
+    })
+
+    it('should add prefixed initialDocumentId for document creation context', () => {
+      const plugin = agentContextPlugin()
+      const resolver = plugin.document?.newDocumentOptions
+
+      const prevItems = [createMockTemplateItem(AGENT_CONTEXT_SCHEMA_TYPE_NAME)]
+
+      const result = callResolver(resolver, prevItems, {
+        type: 'document',
+        documentId: 'doc-123',
+        schemaType: 'reference',
+      })
+
+      expect(result).toHaveLength(1)
+      expect(result?.[0]?.initialDocumentId).toBe('sanity.agentContext.test-uuid-12345')
+    })
+
+    it('should not modify other template items', () => {
+      const plugin = agentContextPlugin()
+      const resolver = plugin.document?.newDocumentOptions
+
+      const prevItems = [createMockTemplateItem('article'), createMockTemplateItem('product')]
+
+      const result = callResolver(resolver, prevItems, {
+        type: 'structure',
+        schemaType: 'article',
+      })
+
+      expect(result).toHaveLength(2)
+      expect(result?.[0]).not.toHaveProperty('initialDocumentId')
+      expect(result?.[1]).not.toHaveProperty('initialDocumentId')
+    })
+
+    it('should use the default sanity.agentContext. prefix for document IDs', () => {
+      const plugin = agentContextPlugin()
+      const resolver = plugin.document?.newDocumentOptions
+
+      const prevItems = [createMockTemplateItem(AGENT_CONTEXT_SCHEMA_TYPE_NAME)]
+
+      const result = callResolver(resolver, prevItems, {
+        type: 'structure',
+        schemaType: AGENT_CONTEXT_SCHEMA_TYPE_NAME,
+      })
+
+      expect(result?.[0]?.initialDocumentId).toMatch(/^sanity\.agentContext\./)
+    })
+
+    it('should use a custom prefix when configured', () => {
+      const plugin = agentContextPlugin({documentIdPrefix: 'agent'})
+      const resolver = plugin.document?.newDocumentOptions
+
+      const prevItems = [createMockTemplateItem(AGENT_CONTEXT_SCHEMA_TYPE_NAME)]
+
+      const result = callResolver(resolver, prevItems, {
+        type: 'structure',
+        schemaType: AGENT_CONTEXT_SCHEMA_TYPE_NAME,
+      })
+
+      expect(result?.[0]?.initialDocumentId).toBe('agent.test-uuid-12345')
+    })
+
+    it('should not register newDocumentOptions when documentIdPrefix is null', () => {
+      const plugin = agentContextPlugin({documentIdPrefix: null})
+      const resolver = plugin.document?.newDocumentOptions
+
+      expect(resolver).toBeUndefined()
+    })
+  })
+
+  describe('document actions', () => {
+    type MockAction = {
+      action?: string
+      displayName?: string;
+      (props: unknown): unknown
+    }
+
+    const createMockAction = (action?: string): MockAction => {
+      const fn = vi.fn() as unknown as MockAction
+      fn.action = action
+      return fn
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const callActionsResolver = (resolver: any, prevActions: MockAction[], schemaType: string) => {
+      return resolver?.(prevActions, {schemaType}) as MockAction[] | undefined
+    }
+
+    it('should replace the duplicate action for agent context type', () => {
+      const plugin = agentContextPlugin()
+      const resolver = plugin.document?.actions
+
+      const prevActions = [createMockAction('publish'), createMockAction('duplicate')]
+
+      const result = callActionsResolver(resolver, prevActions, AGENT_CONTEXT_SCHEMA_TYPE_NAME)
+
+      expect(result).toHaveLength(2)
+      expect(result?.[0]?.action).toBe('publish')
+      expect(result?.[1]?.action).toBe('duplicate')
+      expect(result?.[1]?.displayName).toBe('AgentContextDuplicateAction')
+    })
+
+    it('should not modify actions for other schema types', () => {
+      const plugin = agentContextPlugin()
+      const resolver = plugin.document?.actions
+
+      const duplicateAction = createMockAction('duplicate')
+      const prevActions = [createMockAction('publish'), duplicateAction]
+
+      const result = callActionsResolver(resolver, prevActions, 'article')
+
+      expect(result).toHaveLength(2)
+      expect(result?.[1]).toBe(duplicateAction)
+    })
+
+    it('should preserve non-duplicate actions for agent context type', () => {
+      const plugin = agentContextPlugin()
+      const resolver = plugin.document?.actions
+
+      const publishAction = createMockAction('publish')
+      const deleteAction = createMockAction('delete')
+      const prevActions = [publishAction, createMockAction('duplicate'), deleteAction]
+
+      const result = callActionsResolver(resolver, prevActions, AGENT_CONTEXT_SCHEMA_TYPE_NAME)
+
+      expect(result).toHaveLength(3)
+      expect(result?.[0]).toBe(publishAction)
+      expect(result?.[2]).toBe(deleteAction)
+    })
+
+    it('should produce a duplicate action that uses the sanity.agentContext. prefix', () => {
+      const plugin = agentContextPlugin()
+      const resolver = plugin.document?.actions
+
+      const prevActions = [createMockAction('duplicate')]
+
+      const result = callActionsResolver(resolver, prevActions, AGENT_CONTEXT_SCHEMA_TYPE_NAME)
+
+      const replacedAction = result?.[0]
+      expect(replacedAction?.displayName).toBe('AgentContextDuplicateAction')
+    })
+
+    it('should not register actions when documentIdPrefix is null', () => {
+      const plugin = agentContextPlugin({documentIdPrefix: null})
+      const resolver = plugin.document?.actions
+
+      expect(resolver).toBeUndefined()
+    })
+  })
+
+  describe('plugin options', () => {
+    it('should use the default prefix when no options are provided', () => {
+      const plugin = agentContextPlugin()
+      expect(plugin.name).toBe('sanity/agent-context/plugin')
+    })
+
+    it('should accept a custom documentIdPrefix', () => {
+      const plugin = agentContextPlugin({documentIdPrefix: 'private'})
+      expect(plugin.name).toBe('sanity/agent-context/plugin')
+    })
+
+    it('should accept null to disable prefixing', () => {
+      const plugin = agentContextPlugin({documentIdPrefix: null})
+      expect(plugin.name).toBe('sanity/agent-context/plugin')
+    })
+
+    it('should throw if documentIdPrefix is an empty string', () => {
+      expect(() => agentContextPlugin({documentIdPrefix: ''})).toThrow(
+        /\[@sanity\/agent-context\]: `documentIdPrefix` must be a non-empty string or null, but was ""/,
+      )
+    })
+  })
+
+  describe('AGENT_CONTEXT_DEFAULT_DOCUMENT_ID_PREFIX', () => {
+    it('should be "sanity.agentContext"', () => {
+      expect(AGENT_CONTEXT_DEFAULT_DOCUMENT_ID_PREFIX).toBe('sanity.agentContext')
+    })
+
+    it('should not be empty', () => {
+      expect(AGENT_CONTEXT_DEFAULT_DOCUMENT_ID_PREFIX.length).toBeGreaterThan(0)
+    })
+  })
+})

--- a/packages/agent-context/src/studio/agent-context-plugin/plugin.tsx
+++ b/packages/agent-context/src/studio/agent-context-plugin/plugin.tsx
@@ -1,5 +1,7 @@
-import {definePlugin} from 'sanity'
+import {uuid} from '@sanity/uuid'
+import {definePlugin, type PluginOptions} from 'sanity'
 
+import {createAgentContextDuplicateAction} from './actions'
 import {
   AGENT_CONTEXT_SCHEMA_TITLE,
   AGENT_CONTEXT_SCHEMA_TYPE_NAME,
@@ -7,25 +9,84 @@ import {
 } from './agentContextSchema'
 
 /**
+ * Default document ID prefix for agent context documents.
+ * Document IDs will be formatted as `${prefix}.${uuid}` (e.g., `sanity.agentContext.abc123...`).
+ * Documents with a '.' in the ID are hidden from public API queries in public datasets.
+ * @beta
+ */
+export const AGENT_CONTEXT_DEFAULT_DOCUMENT_ID_PREFIX = 'sanity.agentContext'
+
+/**
+ * Options for the agent context plugin.
+ * @beta
+ */
+export interface AgentContextPluginOptions {
+  /**
+   * Document ID prefix for agent context documents.
+   * - When a string: Creates document IDs like `${prefix}.${uuid}` (e.g., `sanity.agentContext.abc123...`)
+   * - When `null`: Disables prefixing, creates document IDs as just `${uuid}`
+   * - When `undefined` or not provided: Uses the default `'sanity.agentContext'` prefix
+   * Documents with a '.' in the ID are hidden from public API queries in public datasets.
+   * @defaultValue 'sanity.agentContext'
+   */
+  documentIdPrefix?: string | null
+}
+
+/**
  * The plugin for the agent context.
  * @beta
  */
-export const agentContextPlugin = definePlugin({
-  name: 'sanity/agent-context/plugin',
+export const agentContextPlugin = definePlugin<AgentContextPluginOptions | void>((options) => {
+  // undefined or not provided → use default
+  // null → disable prefixing
+  // string → use as prefix
+  const documentIdPrefix =
+    options?.documentIdPrefix === undefined ? AGENT_CONTEXT_DEFAULT_DOCUMENT_ID_PREFIX : options.documentIdPrefix
 
-  schema: {
-    types: [agentContextSchema],
+  if (documentIdPrefix === '') {
+    throw new Error(
+      `[@sanity/agent-context]: \`documentIdPrefix\` must be a non-empty string or null, but was ""`,
+    )
+  }
 
-    // Add template configuration for the `sanity.agentContext` type
-    // as the sanity.* namespace is filtered by default.
-    templates: (prev) => [
-      ...prev,
-      {
-        id: AGENT_CONTEXT_SCHEMA_TYPE_NAME,
-        title: AGENT_CONTEXT_SCHEMA_TITLE,
-        schemaType: AGENT_CONTEXT_SCHEMA_TYPE_NAME,
-        value: {},
-      },
-    ],
-  },
+  const plugin = {
+    name: 'sanity/agent-context/plugin',
+    schema: {
+      types: [agentContextSchema],
+      templates: (prev) => [
+        ...prev,
+        {
+          id: AGENT_CONTEXT_SCHEMA_TYPE_NAME,
+          title: AGENT_CONTEXT_SCHEMA_TITLE,
+          schemaType: AGENT_CONTEXT_SCHEMA_TYPE_NAME,
+          value: {},
+        },
+      ],
+    },
+  } satisfies PluginOptions
+
+  return documentIdPrefix === null
+    ? plugin
+    : {
+        ...plugin,
+        document: {
+          newDocumentOptions: (prev, context) =>
+            context.creationContext.type === 'global'
+              ? prev.filter((item) => item.templateId !== AGENT_CONTEXT_SCHEMA_TYPE_NAME)
+              : prev.map((item) =>
+                  item.templateId === AGENT_CONTEXT_SCHEMA_TYPE_NAME
+                    ? {...item, initialDocumentId: `${documentIdPrefix}.${uuid()}`}
+                    : item,
+                ),
+
+          actions: (prev, context) =>
+            context.schemaType === AGENT_CONTEXT_SCHEMA_TYPE_NAME
+              ? prev.map((action) =>
+                  action.action === 'duplicate'
+                    ? createAgentContextDuplicateAction(documentIdPrefix)
+                    : action,
+                )
+              : prev,
+        },
+      }
 })

--- a/packages/agent-context/src/studio/index.ts
+++ b/packages/agent-context/src/studio/index.ts
@@ -1,6 +1,11 @@
 // Add exports here for the `@sanity/agent-context/studio` package
 export {
+  AGENT_CONTEXT_SCHEMA_TITLE,
   AGENT_CONTEXT_SCHEMA_TYPE_NAME,
   agentContextSchema,
 } from './agent-context-plugin/agentContextSchema'
-export {agentContextPlugin} from './agent-context-plugin/plugin'
+export {
+  AGENT_CONTEXT_DEFAULT_DOCUMENT_ID_PREFIX,
+  agentContextPlugin,
+  type AgentContextPluginOptions,
+} from './agent-context-plugin/plugin'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -243,6 +243,9 @@ importers:
       '@sanity/ui':
         specifier: ^3
         version: 3.1.11(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.3(react@19.2.3))(react-is@19.2.4)(react@19.2.3)(styled-components@6.3.8(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
+      '@sanity/uuid':
+        specifier: ^3.0.2
+        version: 3.0.2
       '@types/react':
         specifier: ^19
         version: 19.2.8
@@ -258,6 +261,9 @@ importers:
       react-dom:
         specifier: ^19
         version: 19.2.3(react@19.2.3)
+      rxjs:
+        specifier: ^7
+        version: 7.8.2
       sanity:
         specifier: ^5.8.0
         version: 5.8.0(@emotion/is-prop-valid@1.4.0)(@types/node@25.0.9)(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(babel-plugin-react-compiler@1.0.0)(jiti@2.6.1)(lightningcss@1.30.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(styled-components@6.3.8(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(terser@5.44.1)(tsx@4.21.0)(typescript@5.9.3)(vitest@4.0.17(@opentelemetry/api@1.9.0)(@types/node@25.0.9)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))(yaml@2.8.2)


### PR DESCRIPTION
## Context

**Situation**: Agent context documents (`sanity.agentContext`) store AI instructions that may contain sensitive content — system prompts, access scoping rules, internal business logic.

**Complication**: On public datasets, any document with a plain UUID as its `_id` is queryable via the public API. Sanity Studio has multiple entry points for document creation (global "+" menu, pane header "+", duplicate action, reference inputs, direct URLs, API mutations), and all of them generate plain UUIDs by default. There is no schema-level hook to enforce a custom ID format.

**Question**: How do we ensure agent context documents are created with private IDs across all Studio creation flows the plugin can control?

**Answer**: Documents with a `.` in the ID (e.g., `sanity.agentContext.abc123`) are hidden from public API queries. This PR adds a configurable document ID prefix that enforces this convention across the three creation flows a plugin can guard.

## What this PR does

- **Pane header "+" button** — sets `initialDocumentId` with the prefix via `document.newDocumentOptions`
- **Global "+" menu** — filters out the type entirely (the global menu doesn't support custom IDs)
- **Duplicate action** — replaces the built-in duplicate with a custom `AgentContextDuplicateAction` that generates prefixed IDs

The default prefix is `sanity.agentContext`. It can be customized via `agentContextPlugin({ documentIdPrefix: 'myPrefix' })` or disabled with `null`.

### Not covered (accepted gaps)

| Entry point | Why |
|---|---|
| Reference input "create new" | `sanity.agentContext` is not a reference target |
| Direct URL / intent navigation | No plugin hook exists; requires core change |
| API / client mutations | Outside Studio scope; documented in README |

## Files changed

- **`plugin.tsx`** — refactored to `definePlugin<Options>`, adds `newDocumentOptions` and `actions` resolvers
- **`actions/AgentContextDuplicateAction.tsx`** — custom duplicate action mirroring core behavior with prefixed IDs
- **`actions/index.ts`** — barrel export
- **`index.ts`** — exports new `AgentContextPluginOptions` type and `AGENT_CONTEXT_DEFAULT_DOCUMENT_ID_PREFIX` constant
- **`README.md`** — documents private ID behavior, custom prefix, and API usage
- **`plugin.test.ts`** + **`AgentContextDuplicateAction.test.ts`** — unit tests

## Test plan

- [ ] Verify pane header "+" creates documents with `sanity.agentContext.` prefix
- [ ] Verify global "+" menu does not show `sanity.agentContext` type
- [ ] Verify duplicate action produces a document with prefixed ID
- [ ] Verify `agentContextPlugin({ documentIdPrefix: null })` disables all prefixing
- [ ] Verify `agentContextPlugin({ documentIdPrefix: 'custom' })` uses the custom prefix
- [ ] Run `pnpm test:unit`