### PR TITLE
feat(insights): add previously found content-gaps to classifier

### DIFF
--- a/examples/ecommerce/studio/functions/classify-conversations.ts
+++ b/examples/ecommerce/studio/functions/classify-conversations.ts
@@ -1,11 +1,11 @@
-import {createClient} from '@sanity/client'
+import {anthropic} from '@ai-sdk/anthropic'
 import {
   classifyConversation,
   getConversationsToClassify,
   getPreviousContentGaps,
 } from '@sanity/agent-context/primitives'
 import {scheduledEventHandler} from '@sanity/functions'
-import {anthropic} from '@ai-sdk/anthropic'
+import {createClient} from '@sanity/client'
 
 // Number of concurrent classification requests.
 const CONCURRENCY = 5

--- a/examples/ecommerce/studio/functions/classify-conversations.ts
+++ b/examples/ecommerce/studio/functions/classify-conversations.ts
@@ -1,10 +1,11 @@
 import {anthropic} from '@ai-sdk/anthropic'
-import {classifyConversation, getConversationsToClassify} from '@sanity/agent-context/primitives'
+import {
+  classifyConversation,
+  getConversationsToClassify,
+  getPreviousContentGaps,
+} from '@sanity/agent-context/primitives'
 import {createClient} from '@sanity/client'
 import {scheduledEventHandler} from '@sanity/functions'
-
-// Maximum conversations to classify per run.
-const BATCH_SIZE = 50
 
 // Number of concurrent classification requests.
 const CONCURRENCY = 5
@@ -20,15 +21,17 @@ export default scheduledEventHandler(async ({context}) => {
     useCdn: false,
   })
 
-  // Find conversations that need classification
-  const conversations = await getConversationsToClassify({
-    client,
-    limit: BATCH_SIZE,
-  })
+  const [conversations, previousContentGaps] = await Promise.all([
+    getConversationsToClassify({client}),
+    getPreviousContentGaps({client}),
+  ])
 
   if (conversations.length === 0) {
+    console.log('[classify-conversations] No conversations to classify')
     return
   }
+
+  console.log(`[classify-conversations] Found ${conversations.length} conversations to classify`)
 
   let successCount = 0
   let errorCount = 0
@@ -43,6 +46,7 @@ export default scheduledEventHandler(async ({context}) => {
           conversationId: conv._id,
           model: anthropic('claude-sonnet-4-5'),
           messages: conv.messages,
+          previousContentGaps,
         })
       }),
     )
@@ -52,12 +56,10 @@ export default scheduledEventHandler(async ({context}) => {
         successCount++
       } else {
         errorCount++
-        console.error(`[classify-conversations] Failed:`, result.reason)
+        console.error(`[classify-conversations] Failed to classify:`, result.reason)
       }
     }
   }
 
-  console.warn(
-    `[classify-conversations] Completed: ${successCount} succeeded, ${errorCount} failed`,
-  )
+  console.log(`[classify-conversations] Completed: ${successCount} succeeded, ${errorCount} failed`)
 })

--- a/examples/ecommerce/studio/functions/classify-conversations.ts
+++ b/examples/ecommerce/studio/functions/classify-conversations.ts
@@ -1,11 +1,11 @@
 import {createClient} from '@sanity/client'
-import {classifyConversation, getConversationsToClassify} from '@sanity/agent-context/primitives'
+import {
+  classifyConversation,
+  getConversationsToClassify,
+  getPreviousContentGaps,
+} from '@sanity/agent-context/primitives'
 import {scheduledEventHandler} from '@sanity/functions'
 import {anthropic} from '@ai-sdk/anthropic'
-
-// Minimum idle time (in minutes) before a conversation is eligible for classification.
-// Conversations with messages newer than this are skipped (still active).
-const COOLDOWN_MINUTES = 10
 
 // Number of concurrent classification requests.
 const CONCURRENCY = 5
@@ -21,11 +21,10 @@ export default scheduledEventHandler(async ({context}) => {
     useCdn: false,
   })
 
-  // Find conversations that need classification
-  const conversations = await getConversationsToClassify({
-    client,
-    cooldownMinutes: COOLDOWN_MINUTES,
-  })
+  const [conversations, previousContentGaps] = await Promise.all([
+    getConversationsToClassify({client}),
+    getPreviousContentGaps({client}),
+  ])
 
   if (conversations.length === 0) {
     console.log('[classify-conversations] No conversations to classify')
@@ -47,6 +46,7 @@ export default scheduledEventHandler(async ({context}) => {
           conversationId: conv._id,
           model: anthropic('claude-sonnet-4-5'),
           messages: conv.messages,
+          previousContentGaps,
         })
       }),
     )

--- a/examples/ecommerce/studio/functions/classify-conversations.ts
+++ b/examples/ecommerce/studio/functions/classify-conversations.ts
@@ -4,8 +4,8 @@ import {
   getConversationsToClassify,
   getPreviousContentGaps,
 } from '@sanity/agent-context/primitives'
-import {scheduledEventHandler} from '@sanity/functions'
 import {createClient} from '@sanity/client'
+import {scheduledEventHandler} from '@sanity/functions'
 
 // Number of concurrent classification requests.
 const CONCURRENCY = 5

--- a/packages/agent-context/src/cli/init-scheduler.ts
+++ b/packages/agent-context/src/cli/init-scheduler.ts
@@ -71,13 +71,10 @@ function generateFunctionContent(provider: ProviderKey): string {
 import {
   classifyConversation,
   getConversationsToClassify,
+  getPreviousContentGaps,
 } from '@sanity/agent-context/primitives'
 import {scheduledEventHandler} from '@sanity/functions'
 ${p.import}
-
-// Minimum idle time (in minutes) before a conversation is eligible for classification.
-// Conversations with messages newer than this are skipped (still active).
-const COOLDOWN_MINUTES = 10
 
 // Number of concurrent classification requests.
 const CONCURRENCY = 5
@@ -93,11 +90,10 @@ export default scheduledEventHandler(async ({context}) => {
     useCdn: false,
   })
 
-  // Find conversations that need classification
-  const conversations = await getConversationsToClassify({
-    client,
-    cooldownMinutes: COOLDOWN_MINUTES,
-  })
+  const [conversations, previousContentGaps] = await Promise.all([
+    getConversationsToClassify({client}),
+    getPreviousContentGaps({client}),
+  ])
 
   if (conversations.length === 0) {
     console.log('[classify-conversations] No conversations to classify')
@@ -119,6 +115,7 @@ export default scheduledEventHandler(async ({context}) => {
           conversationId: conv._id,
           model: ${p.modelCall},
           messages: conv.messages,
+          previousContentGaps,
         })
       }),
     )

--- a/packages/agent-context/src/cli/init-scheduler.ts
+++ b/packages/agent-context/src/cli/init-scheduler.ts
@@ -130,9 +130,7 @@ export default scheduledEventHandler(async ({context}) => {
     }
   }
 
-  console.log(
-    \`[classify-conversations] Completed: \${successCount} succeeded, \${errorCount} failed\`,
-  )
+  console.log(\`[classify-conversations] Completed: \${successCount} succeeded, \${errorCount} failed\`)
 })
 `
 }

--- a/packages/agent-context/src/integrations/ai-sdk/telemetryIntegration.test.ts
+++ b/packages/agent-context/src/integrations/ai-sdk/telemetryIntegration.test.ts
@@ -1,4 +1,4 @@
-import {describe, expect, it, vi, beforeEach} from 'vitest'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
 
 import {sanityInsightsIntegration} from './telemetryIntegration'
 

--- a/packages/agent-context/src/primitives/classifyConversation.test.ts
+++ b/packages/agent-context/src/primitives/classifyConversation.test.ts
@@ -1,6 +1,6 @@
 import {describe, expect, it} from 'vitest'
 
-import {formatMessagesForPrompt} from './classifyConversation'
+import {buildSystemPrompt, formatMessagesForPrompt} from './classifyConversation'
 
 describe('formatMessagesForPrompt', () => {
   it('formats messages with capitalized roles', () => {
@@ -41,5 +41,31 @@ describe('formatMessagesForPrompt', () => {
   it('returns empty string for empty array', () => {
     const result = formatMessagesForPrompt([])
     expect(result).toBe('')
+  })
+})
+
+describe('buildSystemPrompt', () => {
+  it('returns base prompt when no previous gaps provided', () => {
+    const prompt = buildSystemPrompt()
+    expect(prompt).toContain('You are analyzing a conversation')
+    expect(prompt).not.toContain('Previously identified content gaps')
+  })
+
+  it('returns base prompt when previous gaps is empty array', () => {
+    const prompt = buildSystemPrompt([])
+    expect(prompt).not.toContain('Previously identified content gaps')
+  })
+
+  it('includes previous gaps as bulleted list when provided', () => {
+    const prompt = buildSystemPrompt(['billing info', 'return policy'])
+    expect(prompt).toContain('Previously identified content gaps')
+    expect(prompt).toContain('- billing info')
+    expect(prompt).toContain('- return policy')
+  })
+
+  it('instructs the model to reuse existing terms', () => {
+    const prompt = buildSystemPrompt(['billing info'])
+    expect(prompt).toContain('reuse these exact terms when they match')
+    expect(prompt).toContain('only create new terms for genuinely new topics')
   })
 })

--- a/packages/agent-context/src/primitives/classifyConversation.ts
+++ b/packages/agent-context/src/primitives/classifyConversation.ts
@@ -34,6 +34,8 @@ export interface ClassifyConversationOptions {
   model: LanguageModel
   /** Optional messages to classify directly (avoids fetching from Sanity). */
   messages?: Message[]
+  /** Previously observed content gaps to encourage consistent terminology. Use `getPreviousContentGaps` to fetch these. */
+  previousContentGaps?: string[]
 }
 
 const coreMetricsSchema = z.object({
@@ -72,6 +74,23 @@ export function formatMessagesForPrompt(messages: StoredMessage[]): string {
       return `[${role}]: ${m.content || '(no content)'}`
     })
     .join('\n\n')
+}
+
+/** @internal Exported for testing */
+export function buildSystemPrompt(previousContentGaps?: string[]): string {
+  let prompt = `You are analyzing a conversation between a user and an AI assistant.
+Classify the conversation according to the schema provided.
+
+Guidelines:
+- successScore: How well did the assistant resolve the user's needs? 1=complete failure, 5=partially addressed, 10=fully resolved.
+- sentiment: The user's overall emotional tone across the entire conversation.
+- contentGaps: Topics where the assistant lacked information in its knowledge base. Only include gaps where the assistant could not provide information — not refusals, off-topic requests, or tool errors. Be specific (e.g., "international return policy" not "returns"). Empty array if no content gaps.`
+
+  if (previousContentGaps && previousContentGaps.length > 0) {
+    prompt += `\n\nPreviously identified content gaps (reuse these exact terms when they match the gaps you find — only create new terms for genuinely new topics):\n${previousContentGaps.map((g) => `- ${g}`).join('\n')}`
+  }
+
+  return prompt
 }
 
 /**
@@ -135,13 +154,7 @@ export async function classifyConversation(
     messagesToClassify = conversation.messages
   }
 
-  const systemPrompt = `You are analyzing a conversation between a user and an AI assistant.
-Classify the conversation according to the schema provided.
-
-Guidelines:
-- successScore: How well did the assistant resolve the user's needs? 1=complete failure, 5=partially addressed, 10=fully resolved.
-- sentiment: The user's overall emotional tone across the entire conversation.
-- contentGaps: Topics where the assistant lacked information in its knowledge base. Only include gaps where the assistant could not provide information — not refusals, off-topic requests, or tool errors. Be specific (e.g., "international return policy" not "returns"). Empty array if no content gaps.`
+  const systemPrompt = buildSystemPrompt(options.previousContentGaps)
 
   const userPrompt = `Analyze this conversation:
 

--- a/packages/agent-context/src/primitives/getPreviousContentGaps.test.ts
+++ b/packages/agent-context/src/primitives/getPreviousContentGaps.test.ts
@@ -1,0 +1,39 @@
+import {describe, expect, it} from 'vitest'
+
+import {rankByFrequency} from './getPreviousContentGaps'
+
+describe('rankByFrequency', () => {
+  it('deduplicates case-insensitively and preserves first-seen casing', () => {
+    const gaps = ['billing info', 'Billing Info', 'billing info']
+    const result = rankByFrequency(gaps, 50)
+    expect(result).toEqual(['billing info'])
+  })
+
+  it('ranks by frequency descending', () => {
+    const gaps = [
+      'return policy',
+      'billing info',
+      'billing info',
+      'billing info',
+      'return policy',
+      'shipping rates',
+    ]
+    const result = rankByFrequency(gaps, 50)
+    expect(result).toEqual(['billing info', 'return policy', 'shipping rates'])
+  })
+
+  it('respects the limit parameter', () => {
+    const gaps = ['a', 'a', 'b', 'b', 'c', 'd', 'e']
+    const result = rankByFrequency(gaps, 2)
+    expect(result).toHaveLength(2)
+    expect(result).toEqual(['a', 'b'])
+  })
+
+  it('returns empty array for empty input', () => {
+    expect(rankByFrequency([], 50)).toEqual([])
+  })
+
+  it('handles single gap', () => {
+    expect(rankByFrequency(['only one'], 50)).toEqual(['only one'])
+  })
+})

--- a/packages/agent-context/src/primitives/getPreviousContentGaps.ts
+++ b/packages/agent-context/src/primitives/getPreviousContentGaps.ts
@@ -38,8 +38,8 @@ export function rankByFrequency(gaps: string[], limit: number): string[] {
  * Fetches previously identified content gaps from classified conversations,
  * deduplicated and ranked by frequency.
  *
- * Use this to pass consistent terminology to {@link classifyConversation} via the
- * `previousContentGaps` option, reducing duplicate gap descriptions across conversations.
+ * Pass the result to `classifyConversation` via the `previousContentGaps` option
+ * to encourage consistent terminology across classifications.
  *
  * @example
  * ```ts

--- a/packages/agent-context/src/primitives/getPreviousContentGaps.ts
+++ b/packages/agent-context/src/primitives/getPreviousContentGaps.ts
@@ -1,0 +1,87 @@
+import type {SanityClient} from 'sanity'
+
+import {CONVERSATION_SCHEMA_TYPE_NAME} from '../studio/insights/schemas/conversationSchema'
+
+/** @public */
+export interface GetPreviousContentGapsOptions {
+  /** Sanity client with read permissions. */
+  client: SanityClient
+  /** Only include gaps from conversations classified within this many days. Defaults to `30`. */
+  maxAgeDays?: number
+  /** Maximum number of gaps to return, ranked by frequency. Defaults to `50`. */
+  limit?: number
+  /** Optional filter by agent ID. */
+  agentId?: string
+}
+
+/** @internal Exported for testing */
+export function rankByFrequency(gaps: string[], limit: number): string[] {
+  const freq = new Map<string, {canonical: string; count: number}>()
+
+  for (const gap of gaps) {
+    const key = gap.toLowerCase()
+    const entry = freq.get(key)
+    if (entry) {
+      entry.count++
+    } else {
+      freq.set(key, {canonical: gap, count: 1})
+    }
+  }
+
+  return Array.from(freq.values())
+    .sort((a, b) => b.count - a.count)
+    .slice(0, limit)
+    .map((e) => e.canonical)
+}
+
+/**
+ * Fetches previously identified content gaps from classified conversations,
+ * deduplicated and ranked by frequency.
+ *
+ * Use this to pass consistent terminology to {@link classifyConversation} via the
+ * `previousContentGaps` option, reducing duplicate gap descriptions across conversations.
+ *
+ * @example
+ * ```ts
+ * import {getPreviousContentGaps, classifyConversation} from '@sanity/agent-context/primitives'
+ *
+ * const previousContentGaps = await getPreviousContentGaps({client})
+ *
+ * await classifyConversation({
+ *   client,
+ *   conversationId: 'agentconversation-support-bot-thread-123',
+ *   model: openai('gpt-4o-mini'),
+ *   previousContentGaps,
+ * })
+ * ```
+ *
+ * @returns Array of content gap strings, ranked by frequency (most common first).
+ * @public
+ */
+export async function getPreviousContentGaps(
+  options: GetPreviousContentGapsOptions,
+): Promise<string[]> {
+  const {client, maxAgeDays = 30, limit = 50, agentId} = options
+
+  const since = new Date(Date.now() - maxAgeDays * 24 * 60 * 60 * 1000).toISOString()
+
+  const query = `*[
+    _type == $type
+    && defined(coreMetrics.contentGaps)
+    && defined(classifiedAt)
+    && classifiedAt > $since
+    && ($agentId == null || agentId == $agentId)
+  ].coreMetrics.contentGaps[]`
+
+  const allGaps = await client.fetch<string[]>(
+    query,
+    {
+      type: CONVERSATION_SCHEMA_TYPE_NAME,
+      since,
+      agentId: agentId ?? null,
+    },
+    {perspective: 'published'},
+  )
+
+  return rankByFrequency(allGaps, limit)
+}

--- a/packages/agent-context/src/primitives/index.ts
+++ b/packages/agent-context/src/primitives/index.ts
@@ -10,5 +10,7 @@ export type {
   GetConversationsToClassifyOptions,
 } from './getConversationsToClassify'
 export {getConversationsToClassify} from './getConversationsToClassify'
+export type {GetPreviousContentGapsOptions} from './getPreviousContentGaps'
+export {getPreviousContentGaps} from './getPreviousContentGaps'
 export type {Message, MessageRole, SaveConversationOptions} from './saveConversation'
 export {generateConversationId, saveConversation} from './saveConversation'


### PR DESCRIPTION
### Description

To make the classifier describe the same content gaps the same way, we provide it with recently (within 30days old, max 50 entries) found content gaps.

Also removed the use of batch_size limit from the example. I think it's better to recommend classifying everything to avoid confusion.

Introduces a new `getPreviousContentGaps` primitive to find previous content gaps, limited by max 50 items, and classified within the last 30 days (overridable).

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->
