### PR TITLE
fix: only count user and assistant messages in counts

### DIFF
--- a/packages/agent-context/src/studio/insights/dashboard/conversations/ConversationList.tsx
+++ b/packages/agent-context/src/studio/insights/dashboard/conversations/ConversationList.tsx
@@ -80,7 +80,7 @@ const PROJECTION = `{
   _id,
   agentId,
   messagesUpdatedAt,
-  "messageCount": count(messages),
+  "messageCount": count(messages[role in ["user", "assistant"]]),
   "coreMetrics": { "successScore": coreMetrics.successScore, "sentiment": coreMetrics.sentiment, "contentGaps": coreMetrics.contentGaps },
   "firstMessage": messages[role == "user"][0].content
 }`

--- a/packages/agent-context/src/studio/insights/dashboard/overview/useOverviewData.ts
+++ b/packages/agent-context/src/studio/insights/dashboard/overview/useOverviewData.ts
@@ -11,7 +11,7 @@ const SENTIMENT_FILTER = `${BASE_FILTER} && defined(coreMetrics.sentiment)`
 const OVERVIEW_QUERY = `{
   "total": count(*[${BASE_FILTER}]),
   "avgScore": math::avg(*[${SCORED_FILTER}].coreMetrics.successScore),
-  "avgMessages": math::avg(*[${BASE_FILTER}]{"c": count(messages)}.c),
+  "avgMessages": math::avg(*[${BASE_FILTER}]{"c": count(messages[role in ["user", "assistant"]])}.c),
 
   "scoreGood": count(*[${SCORED_FILTER} && coreMetrics.successScore >= 8]),
   "scoreOkay": count(*[${SCORED_FILTER} && coreMetrics.successScore >= 6 && coreMetrics.successScore < 8]),

--- a/packages/agent-context/src/studio/plugin.ts
+++ b/packages/agent-context/src/studio/plugin.ts
@@ -86,7 +86,7 @@ export const agentContextPlugin = definePlugin<AgentContextPluginOptions | void>
       ? [
           {
             name: 'agent-insights',
-            title: 'Insights',
+            title: 'Agent Insights',
             icon: ChartUpwardIcon,
             component: InsightsDashboard,
             router: route.create('/:path', [route.create('/:agentId', [route.create('/:id')])]),


### PR DESCRIPTION
### Description

Fixes weird avg's and counts from counting system and tool messages.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->
