### PR TITLE
feat!: remove `sanity.` _type prefix

### DIFF
--- a/packages/agent-context/README.md
+++ b/packages/agent-context/README.md
@@ -87,7 +87,7 @@ Insights is enabled by default. To disable it:
 agentContextPlugin({insights: {enabled: false}})
 ```
 
-This registers the `sanity.agentContextConversation` schema and adds an "Agent Insights" dashboard to your Studio.
+This registers the `sanityAgentContextConversation` schema and adds an "Agent Insights" dashboard to your Studio.
 
 ### 2. Add Telemetry
 

--- a/packages/agent-context/src/insights/constants.ts
+++ b/packages/agent-context/src/insights/constants.ts
@@ -3,4 +3,4 @@
  *
  * @public
  */
-export const CONVERSATION_SCHEMA_TYPE_NAME = 'sanity.agentContextConversation'
+export const CONVERSATION_SCHEMA_TYPE_NAME = 'sanityAgentContextConversation'

--- a/packages/agent-context/src/insights/getConversationsToClassify.test.ts
+++ b/packages/agent-context/src/insights/getConversationsToClassify.test.ts
@@ -80,7 +80,7 @@ describe('getConversationsToClassify', () => {
     })
 
     const [, params] = mockClient.fetch.mock.calls[0] as [string, Record<string, unknown>]
-    expect(params['type']).toBe('sanity.agentContextConversation')
+    expect(params['type']).toBe('sanityAgentContextConversation')
   })
 
   it('query filters for unclassified or updated conversations using messagesUpdatedAt', async () => {

--- a/packages/agent-context/src/insights/saveConversation.test.ts
+++ b/packages/agent-context/src/insights/saveConversation.test.ts
@@ -101,7 +101,7 @@ describe('saveConversation', () => {
       expect(createIfNotExistsMock).toHaveBeenCalledWith(
         expect.objectContaining({
           _id: result,
-          _type: 'sanity.agentContextConversation',
+          _type: 'sanityAgentContextConversation',
           agentId: 'test-agent',
           threadId: 'test-thread',
         }),

--- a/skills/create-agent-with-sanity-context/references/conversation-classification.md
+++ b/skills/create-agent-with-sanity-context/references/conversation-classification.md
@@ -338,7 +338,7 @@ The `sanityInsightsIntegration` hooks into AI SDK's telemetry system:
 - **On request start**: Captures input messages
 - **On request finish**: Combines with response messages and saves to Sanity
 
-Conversations are saved as `sanity.agentContextConversation` documents (provided by the plugin).
+Conversations are saved as `sanityAgentContextConversation` documents (provided by the plugin).
 
 ### Classification
 
@@ -389,7 +389,7 @@ The robot token isn't configured correctly. Verify:
 ### Classification not finding conversations
 
 - Conversations need at least 10 minutes of idle time before classification
-- Check that telemetry is saving conversations: look for `sanity.agentContextConversation` documents in Studio
+- Check that telemetry is saving conversations: look for `sanityAgentContextConversation` documents in Studio
 
 ## Insights API Reference
 


### PR DESCRIPTION
### Description

Allows Agent Context conversation documents to be surfaced to CA and MCP by not considering it as an internal type.

CA and MCP can now be used to analyze conversations and classification results, and also 

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->
