### PR TITLE
fix(skill): add note about studio structure for context docs

### DIFF
--- a/skills/create-agent-with-sanity-context/references/studio-setup.md
+++ b/skills/create-agent-with-sanity-context/references/studio-setup.md
@@ -62,9 +62,11 @@ This registers the `sanity.agentContext` document type and enables Insights (con
 agentContextPlugin({insights: false})
 ```
 
-## Customize Structure Tool (Optional)
+## Update the Structure Tool
 
-To organize agent-related documents in a dedicated section, see [ecommerce/studio/sanity.config.ts](ecommerce/studio/sanity.config.ts) for an example.
+Check whether `structureTool()` in the Studio config has a `structure` prop. If it does, the Studio uses an explicit structure — document types only appear in the sidebar if they are listed there. The agent context types (`AGENT_CONTEXT_SCHEMA_TYPE_NAME`, `CONVERSATION_SCHEMA_TYPE_NAME`) must be added to the existing structure, or they will be invisible. If there is no `structure` prop, types appear automatically and no changes are needed.
+
+See [ecommerce/studio/sanity.config.ts](ecommerce/studio/sanity.config.ts) for an example that groups agent types under an "Agents" section. Adapt the placement to match the project's existing organization.
 
 ## Create an Agent Context document
 


### PR DESCRIPTION
### Description

Explicitly tell the agent to make sure new agent context documents are visible in the studio structure.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->
