### PR TITLE
feat: attach knowledge bases to a Context document

### DIFF
--- a/packages/context/src/studio/context-document/contextSchema.test.ts
+++ b/packages/context/src/studio/context-document/contextSchema.test.ts
@@ -42,6 +42,27 @@ describe('contextSchema', () => {
     })
   })
 
+  describe('groqEnabled field', () => {
+    it('should define groqEnabled as a boolean', () => {
+      const field = contextSchema.fields.find((f) => f.name === 'groqEnabled')
+      expect(field).toBeDefined()
+      expect(field?.type).toBe('boolean')
+    })
+
+    it('should default groqEnabled to true', () => {
+      expect(contextSchema.initialValue).toHaveProperty('groqEnabled', true)
+    })
+  })
+
+  describe('knowledgeBaseIds field', () => {
+    it('should define knowledgeBaseIds as an array of strings', () => {
+      const field = contextSchema.fields.find((f) => f.name === 'knowledgeBaseIds')
+      expect(field).toBeDefined()
+      expect(field?.type).toBe('array')
+      expect((field as {of?: {type: string}[]})?.of).toEqual([{type: 'string'}])
+    })
+  })
+
   describe('other fields', () => {
     it('should include the name field', () => {
       const nameField = contextSchema.fields.find((field) => field.name === 'name')

--- a/packages/context/src/studio/context-document/contextSchema.test.ts
+++ b/packages/context/src/studio/context-document/contextSchema.test.ts
@@ -42,15 +42,15 @@ describe('contextSchema', () => {
     })
   })
 
-  describe('groqEnabled field', () => {
-    it('should define groqEnabled as a boolean', () => {
-      const field = contextSchema.fields.find((f) => f.name === 'groqEnabled')
+  describe('mode field', () => {
+    it('should define mode as a string', () => {
+      const field = contextSchema.fields.find((f) => f.name === 'mode')
       expect(field).toBeDefined()
-      expect(field?.type).toBe('boolean')
+      expect(field?.type).toBe('string')
     })
 
-    it('should default groqEnabled to true', () => {
-      expect(contextSchema.initialValue).toHaveProperty('groqEnabled', true)
+    it('should default mode to groq', () => {
+      expect(contextSchema.initialValue).toHaveProperty('mode', 'groq')
     })
   })
 

--- a/packages/context/src/studio/context-document/contextSchema.test.ts
+++ b/packages/context/src/studio/context-document/contextSchema.test.ts
@@ -54,9 +54,9 @@ describe('contextSchema', () => {
     })
   })
 
-  describe('knowledgeBaseIds field', () => {
-    it('should define knowledgeBaseIds as an array of strings', () => {
-      const field = contextSchema.fields.find((f) => f.name === 'knowledgeBaseIds')
+  describe('knowledgeBases field', () => {
+    it('should define knowledgeBases as an array of strings', () => {
+      const field = contextSchema.fields.find((f) => f.name === 'knowledgeBases')
       expect(field).toBeDefined()
       expect(field?.type).toBe('array')
       expect((field as {of?: {type: string}[]})?.of).toEqual([{type: 'string'}])

--- a/packages/context/src/studio/context-document/contextSchema.ts
+++ b/packages/context/src/studio/context-document/contextSchema.ts
@@ -57,7 +57,8 @@ export const contextSchema = defineType({
     }),
     defineField({
       name: 'mode',
-      title: 'Content access mode',
+      title: 'Content source',
+      description: 'Choose how agents access your content.',
       type: 'string',
       validation: (Rule) => Rule.required(),
       options: {

--- a/packages/context/src/studio/context-document/contextSchema.ts
+++ b/packages/context/src/studio/context-document/contextSchema.ts
@@ -25,6 +25,7 @@ export const contextSchema = defineType({
   icon: DatabaseIcon,
   initialValue: {
     version: '1',
+    groqEnabled: true,
   },
   components: {
     input: ContextDocumentInput,
@@ -54,11 +55,28 @@ export const contextSchema = defineType({
       },
     }),
     defineField({
+      name: 'knowledgeBaseIds',
+      title: 'Knowledge bases',
+      description:
+        'Give agents access to curated knowledge bases so they can find and use that content when answering.',
+      type: 'array',
+      of: [{type: 'string'}],
+    }),
+    defineField({
+      name: 'groqEnabled',
+      title: 'Let agents query all content',
+      description:
+        'Allow agents to search across all your content directly. Stays on when no knowledge base is attached, so agents always have a way to find content.',
+      type: 'boolean',
+    }),
+    defineField({
       name: 'groqFilter',
       title: 'Content filter',
       description:
         'Control what content AI agents can access. Leave empty for full access, or pick specific document types. Use the GROQ tab for advanced filters.',
       type: 'string',
+      // Only relevant when the GROQ tools are enabled — they're what the filter scopes.
+      hidden: ({parent}) => parent?.groqEnabled === false,
       components: {
         input: GroqFilterInput,
       },

--- a/packages/context/src/studio/context-document/contextSchema.ts
+++ b/packages/context/src/studio/context-document/contextSchema.ts
@@ -24,20 +24,9 @@ export const contextSchema = defineType({
   title: CONTEXT_SCHEMA_TITLE,
   type: 'document',
   icon: DatabaseIcon,
-  // Group the direct-query toggle and its content filter into one bordered,
-  // collapsible section. They stay top-level fields in the document (no nested
-  // object), so consumers read `groqEnabled` / `groqFilter` unchanged.
-  fieldsets: [
-    {
-      name: 'directQuery',
-      title: 'Direct content access',
-      description: 'Let agents query your content directly, and scope what they can reach.',
-      options: {collapsible: true, collapsed: false},
-    },
-  ],
   initialValue: {
     version: '1',
-    groqEnabled: true,
+    mode: 'groq',
   },
   components: {
     input: ContextDocumentInput,
@@ -67,23 +56,29 @@ export const contextSchema = defineType({
       },
     }),
     defineField({
+      name: 'mode',
+      title: 'Content access mode',
+      type: 'string',
+      validation: (Rule) => Rule.required(),
+      options: {
+        list: [
+          {title: 'Knowledge base', value: 'knowledge_base'},
+          {title: 'GROQ', value: 'groq'},
+        ],
+        layout: 'radio',
+      },
+    }),
+    defineField({
       name: 'knowledgeBaseIds',
       title: 'Knowledge bases',
       description:
         'Give agents access to curated knowledge bases so they can find and use that content when answering.',
       type: 'array',
       of: [{type: 'string'}],
+      hidden: ({parent}) => parent?.mode !== 'knowledge_base',
       components: {
         input: KnowledgeBaseInput,
       },
-    }),
-    defineField({
-      name: 'groqEnabled',
-      title: 'Let agents query all content',
-      description:
-        'Allow agents to search across all your content directly. Stays on when no knowledge base is attached, so agents always have a way to find content.',
-      type: 'boolean',
-      fieldset: 'directQuery',
     }),
     defineField({
       name: 'groqFilter',
@@ -91,10 +86,7 @@ export const contextSchema = defineType({
       description:
         'Control what content AI agents can access. Leave empty for full access, or pick specific document types. Use the GROQ tab for advanced filters.',
       type: 'string',
-      fieldset: 'directQuery',
-      // The filter only scopes direct querying, so it's inactive (read-only)
-      // when that's off — kept visible (not hidden) so there's no layout jump.
-      readOnly: ({parent}) => parent?.groqEnabled === false,
+      hidden: ({parent}) => parent?.mode !== 'groq',
       components: {
         input: GroqFilterInput,
       },

--- a/packages/context/src/studio/context-document/contextSchema.ts
+++ b/packages/context/src/studio/context-document/contextSchema.ts
@@ -4,6 +4,7 @@ import {defineField, defineType} from 'sanity'
 import {ContextDocumentInput} from './context-document-input/ContextDocumentInput'
 import {GroqFilterInput} from './groq-filter-input/GroqFilterInput'
 import {validateGroqFilter} from './groq-filter-input/groqUtils'
+import {KnowledgeBaseInput} from './knowledge-base-input/KnowledgeBaseInput'
 
 /** @public */
 export const CONTEXT_SCHEMA_TYPE_NAME = 'sanity.agentContext'
@@ -23,6 +24,17 @@ export const contextSchema = defineType({
   title: CONTEXT_SCHEMA_TITLE,
   type: 'document',
   icon: DatabaseIcon,
+  // Group the direct-query toggle and its content filter into one bordered,
+  // collapsible section. They stay top-level fields in the document (no nested
+  // object), so consumers read `groqEnabled` / `groqFilter` unchanged.
+  fieldsets: [
+    {
+      name: 'directQuery',
+      title: 'Direct content access',
+      description: 'Let agents query your content directly, and scope what they can reach.',
+      options: {collapsible: true, collapsed: false},
+    },
+  ],
   initialValue: {
     version: '1',
     groqEnabled: true,
@@ -61,6 +73,9 @@ export const contextSchema = defineType({
         'Give agents access to curated knowledge bases so they can find and use that content when answering.',
       type: 'array',
       of: [{type: 'string'}],
+      components: {
+        input: KnowledgeBaseInput,
+      },
     }),
     defineField({
       name: 'groqEnabled',
@@ -68,6 +83,7 @@ export const contextSchema = defineType({
       description:
         'Allow agents to search across all your content directly. Stays on when no knowledge base is attached, so agents always have a way to find content.',
       type: 'boolean',
+      fieldset: 'directQuery',
     }),
     defineField({
       name: 'groqFilter',
@@ -75,8 +91,10 @@ export const contextSchema = defineType({
       description:
         'Control what content AI agents can access. Leave empty for full access, or pick specific document types. Use the GROQ tab for advanced filters.',
       type: 'string',
-      // Only relevant when the GROQ tools are enabled — they're what the filter scopes.
-      hidden: ({parent}) => parent?.groqEnabled === false,
+      fieldset: 'directQuery',
+      // The filter only scopes direct querying, so it's inactive (read-only)
+      // when that's off — kept visible (not hidden) so there's no layout jump.
+      readOnly: ({parent}) => parent?.groqEnabled === false,
       components: {
         input: GroqFilterInput,
       },

--- a/packages/context/src/studio/context-document/contextSchema.ts
+++ b/packages/context/src/studio/context-document/contextSchema.ts
@@ -70,7 +70,7 @@ export const contextSchema = defineType({
       },
     }),
     defineField({
-      name: 'knowledgeBaseIds',
+      name: 'knowledgeBases',
       title: 'Knowledge bases',
       description:
         'Give agents access to curated knowledge bases so they can find and use that content when answering.',

--- a/packages/context/src/studio/context-document/groq-filter-input/GroqFilterInput.tsx
+++ b/packages/context/src/studio/context-document/groq-filter-input/GroqFilterInput.tsx
@@ -55,7 +55,7 @@ const TAB_IDS = {
 const ITEM_HEIGHT = 43
 
 export function GroqFilterInput(props: StringInputProps) {
-  const {value, onChange, elementProps} = props
+  const {value, onChange, elementProps, readOnly} = props
   const {ref: refProp, ...restElementProps} = elementProps || {}
 
   const [open, setOpen] = useState<boolean>(false)
@@ -107,13 +107,14 @@ export function GroqFilterInput(props: StringInputProps) {
   // 3. Transform the updated selected types into a GROQ query and set it as the new value.
   const handleDocumentTypeItemClick = useCallback(
     (item: string) => {
+      if (readOnly) return
       const nextValue = selectedTypes.includes(item)
         ? selectedTypes.filter((t) => t !== item)
         : [...selectedTypes, item]
 
       onChange(nextValue.length > 0 ? set(listToQuery(nextValue)) : unset())
     },
-    [selectedTypes, onChange],
+    [selectedTypes, onChange, readOnly],
   )
 
   const closeList = useCallback(() => {
@@ -289,6 +290,7 @@ export function GroqFilterInput(props: StringInputProps) {
                   {...restElementProps}
                   autoComplete="off"
                   border={false}
+                  disabled={readOnly}
                   onChange={(event) => setSearchQuery(event.currentTarget.value)}
                   onKeyDown={handleTextInputKeyDown}
                   placeholder="Search for document types"
@@ -301,7 +303,7 @@ export function GroqFilterInput(props: StringInputProps) {
               <Flex align="center" justify="center" sizing="border" padding={1} height="fill">
                 <Button
                   aria-label="Open document types list"
-                  disabled={isListOpen}
+                  disabled={isListOpen || readOnly}
                   icon={ChevronDownIcon}
                   mode="bleed"
                   onClick={handleToggleList}
@@ -327,6 +329,7 @@ export function GroqFilterInput(props: StringInputProps) {
 
                     <Button
                       aria-label="Remove {type} from filter"
+                      disabled={readOnly}
                       fontSize={0}
                       icon={CloseIcon}
                       mode="bleed"
@@ -351,6 +354,7 @@ export function GroqFilterInput(props: StringInputProps) {
         <Stack space={3}>
           <GroqFilterTextArea
             {...restElementProps}
+            readOnly={readOnly}
             onChange={(event) =>
               onChange(event.currentTarget.value ? set(event.currentTarget.value) : unset())
             }

--- a/packages/context/src/studio/context-document/knowledge-base-input/KnowledgeBaseInput.tsx
+++ b/packages/context/src/studio/context-document/knowledge-base-input/KnowledgeBaseInput.tsx
@@ -1,6 +1,6 @@
 import {DatabaseIcon, ErrorOutlineIcon} from '@sanity/icons'
 import {Box, Button, Card, Checkbox, Flex, Spinner, Stack, Text} from '@sanity/ui'
-import {useCallback} from 'react'
+import {useCallback, useMemo} from 'react'
 import {type ArrayOfPrimitivesInputProps, set, unset} from 'sanity'
 
 import type {KnowledgeBase} from './atlas'
@@ -26,7 +26,7 @@ function isSelectable(kb: KnowledgeBase): boolean {
  */
 export function KnowledgeBaseInput(props: ArrayOfPrimitivesInputProps) {
   const {onChange} = props
-  const selected = (props.value ?? []) as string[]
+  const selected = useMemo(() => (props.value ?? []) as string[], [props.value])
   const {knowledgeBases, loading, error, retry} = useKnowledgeBases()
 
   const toggle = useCallback(
@@ -42,6 +42,7 @@ export function KnowledgeBaseInput(props: ArrayOfPrimitivesInputProps) {
       <Card padding={4} radius={2} border>
         <Flex align="center" gap={3}>
           <Spinner muted />
+
           <Text size={1} muted>
             Loading knowledge bases…
           </Text>
@@ -58,13 +59,16 @@ export function KnowledgeBaseInput(props: ArrayOfPrimitivesInputProps) {
             <Text size={1}>
               <ErrorOutlineIcon />
             </Text>
+
             <Text size={1} weight="medium">
               Couldn’t load knowledge bases
             </Text>
           </Flex>
+
           <Text size={1} muted>
             {error}
           </Text>
+
           <Box>
             <Button fontSize={1} mode="ghost" onClick={retry} padding={2} text="Retry" />
           </Box>
@@ -125,15 +129,18 @@ function KnowledgeBaseRow({
             onChange={(e) => onToggle(kb.id, e.currentTarget.checked)}
           />
         </Box>
+
         <Box flex={1}>
           <Stack space={2}>
             <Flex align="center" gap={2}>
               <Text size={1}>
                 <DatabaseIcon />
               </Text>
+
               <Text size={1} weight="medium">
                 {kb.name}
               </Text>
+
               {kb.state && kb.state !== 'ready' && (
                 <Text size={0} muted>
                   ({kb.state}
@@ -141,6 +148,7 @@ function KnowledgeBaseRow({
                 </Text>
               )}
             </Flex>
+
             {kb.description && (
               <Text size={1} muted>
                 {kb.description}

--- a/packages/context/src/studio/context-document/knowledge-base-input/KnowledgeBaseInput.tsx
+++ b/packages/context/src/studio/context-document/knowledge-base-input/KnowledgeBaseInput.tsx
@@ -135,8 +135,7 @@ function KnowledgeBaseRow({
 
           {kb.state && kb.state !== 'ready' && (
             <Text size={0} muted>
-              ({kb.state}
-              {disabled ? ' — not built yet' : ''})
+              {`(${kb.state}${disabled ? ' — not built yet' : ''})`}
             </Text>
           )}
         </Flex>

--- a/packages/context/src/studio/context-document/knowledge-base-input/KnowledgeBaseInput.tsx
+++ b/packages/context/src/studio/context-document/knowledge-base-input/KnowledgeBaseInput.tsx
@@ -1,4 +1,4 @@
-import {DatabaseIcon, ErrorOutlineIcon} from '@sanity/icons'
+import {ErrorOutlineIcon} from '@sanity/icons'
 import {Box, Button, Card, Checkbox, Flex, Spinner, Stack, Text} from '@sanity/ui'
 import {useCallback, useMemo} from 'react'
 import {type ArrayOfPrimitivesInputProps, set, unset} from 'sanity'
@@ -121,42 +121,32 @@ function KnowledgeBaseRow({
       tone={checked ? 'primary' : 'default'}
       style={{cursor: disabled ? 'not-allowed' : 'pointer', opacity: disabled ? 0.6 : 1}}
     >
-      <Flex align="flex-start" gap={3}>
-        <Box paddingTop={1}>
+      <Stack space={3}>
+        <Flex align="center" gap={3}>
           <Checkbox
             checked={checked}
             disabled={disabled}
             onChange={(e) => onToggle(kb.id, e.currentTarget.checked)}
           />
-        </Box>
 
-        <Box flex={1}>
-          <Stack space={2}>
-            <Flex align="center" gap={2}>
-              <Text size={1}>
-                <DatabaseIcon />
-              </Text>
+          <Text size={1} weight="medium">
+            {kb.name}
+          </Text>
 
-              <Text size={1} weight="medium">
-                {kb.name}
-              </Text>
+          {kb.state && kb.state !== 'ready' && (
+            <Text size={0} muted>
+              ({kb.state}
+              {disabled ? ' — not built yet' : ''})
+            </Text>
+          )}
+        </Flex>
 
-              {kb.state && kb.state !== 'ready' && (
-                <Text size={0} muted>
-                  ({kb.state}
-                  {disabled ? ' — not built yet' : ''})
-                </Text>
-              )}
-            </Flex>
-
-            {kb.description && (
-              <Text size={1} muted>
-                {kb.description}
-              </Text>
-            )}
-          </Stack>
-        </Box>
-      </Flex>
+        {kb.description && (
+          <Text size={1} muted>
+            {kb.description}
+          </Text>
+        )}
+      </Stack>
     </Card>
   )
 }

--- a/packages/context/src/studio/context-document/knowledge-base-input/KnowledgeBaseInput.tsx
+++ b/packages/context/src/studio/context-document/knowledge-base-input/KnowledgeBaseInput.tsx
@@ -1,0 +1,154 @@
+import {DatabaseIcon, ErrorOutlineIcon} from '@sanity/icons'
+import {Box, Button, Card, Checkbox, Flex, Spinner, Stack, Text} from '@sanity/ui'
+import {useCallback} from 'react'
+import {type ArrayOfPrimitivesInputProps, set, unset} from 'sanity'
+
+import type {KnowledgeBase} from './atlas'
+import {useKnowledgeBases} from './useKnowledgeBases'
+
+/**
+ * Knowledge-base states that can be attached. 'ready' and 'review' are built
+ * (have content to read); states like 'created' are not yet built, so attaching
+ * them would give the agent an empty outline — those stay disabled. A missing
+ * state is treated as selectable (don't block on unknown shapes).
+ */
+const SELECTABLE_STATES = new Set(['ready', 'review'])
+
+function isSelectable(kb: KnowledgeBase): boolean {
+  return kb.state === undefined || SELECTABLE_STATES.has(kb.state)
+}
+
+/**
+ * Custom input for the `knowledgeBaseIds` field. Instead of typing knowledge
+ * base ids by hand, the editor picks from the org's knowledge bases (fetched
+ * from Atlas). The field stores the selected ids; everything else (slug, name,
+ * description) is resolved at runtime by context-mcp.
+ */
+export function KnowledgeBaseInput(props: ArrayOfPrimitivesInputProps) {
+  const {onChange} = props
+  const selected = (props.value ?? []) as string[]
+  const {knowledgeBases, loading, error, retry} = useKnowledgeBases()
+
+  const toggle = useCallback(
+    (id: string, checked: boolean) => {
+      const next = checked ? [...selected, id] : selected.filter((x) => x !== id)
+      onChange(next.length > 0 ? set(next) : unset())
+    },
+    [onChange, selected],
+  )
+
+  if (loading) {
+    return (
+      <Card padding={4} radius={2} border>
+        <Flex align="center" gap={3}>
+          <Spinner muted />
+          <Text size={1} muted>
+            Loading knowledge bases…
+          </Text>
+        </Flex>
+      </Card>
+    )
+  }
+
+  if (error) {
+    return (
+      <Card padding={4} radius={2} tone="critical" border>
+        <Stack space={3}>
+          <Flex align="center" gap={2}>
+            <Text size={1}>
+              <ErrorOutlineIcon />
+            </Text>
+            <Text size={1} weight="medium">
+              Couldn’t load knowledge bases
+            </Text>
+          </Flex>
+          <Text size={1} muted>
+            {error}
+          </Text>
+          <Box>
+            <Button fontSize={1} mode="ghost" onClick={retry} padding={2} text="Retry" />
+          </Box>
+        </Stack>
+      </Card>
+    )
+  }
+
+  if (knowledgeBases.length === 0) {
+    return (
+      <Card padding={4} radius={2} tone="transparent" border>
+        <Text size={1} muted>
+          No knowledge bases found in this organization. Create one to attach it here.
+        </Text>
+      </Card>
+    )
+  }
+
+  return (
+    <Stack space={2}>
+      {knowledgeBases.map((kb) => (
+        <KnowledgeBaseRow
+          key={kb.id}
+          knowledgeBase={kb}
+          checked={selected.includes(kb.id)}
+          onToggle={toggle}
+        />
+      ))}
+    </Stack>
+  )
+}
+
+function KnowledgeBaseRow({
+  knowledgeBase: kb,
+  checked,
+  onToggle,
+}: {
+  knowledgeBase: KnowledgeBase
+  checked: boolean
+  onToggle: (id: string, checked: boolean) => void
+}) {
+  const disabled = !isSelectable(kb)
+
+  return (
+    <Card
+      as="label"
+      padding={3}
+      radius={2}
+      border
+      tone={checked ? 'primary' : 'default'}
+      style={{cursor: disabled ? 'not-allowed' : 'pointer', opacity: disabled ? 0.6 : 1}}
+    >
+      <Flex align="flex-start" gap={3}>
+        <Box paddingTop={1}>
+          <Checkbox
+            checked={checked}
+            disabled={disabled}
+            onChange={(e) => onToggle(kb.id, e.currentTarget.checked)}
+          />
+        </Box>
+        <Box flex={1}>
+          <Stack space={2}>
+            <Flex align="center" gap={2}>
+              <Text size={1}>
+                <DatabaseIcon />
+              </Text>
+              <Text size={1} weight="medium">
+                {kb.name}
+              </Text>
+              {kb.state && kb.state !== 'ready' && (
+                <Text size={0} muted>
+                  ({kb.state}
+                  {disabled ? ' — not built yet' : ''})
+                </Text>
+              )}
+            </Flex>
+            {kb.description && (
+              <Text size={1} muted>
+                {kb.description}
+              </Text>
+            )}
+          </Stack>
+        </Box>
+      </Flex>
+    </Card>
+  )
+}

--- a/packages/context/src/studio/context-document/knowledge-base-input/KnowledgeBaseInput.tsx
+++ b/packages/context/src/studio/context-document/knowledge-base-input/KnowledgeBaseInput.tsx
@@ -19,10 +19,11 @@ function isSelectable(kb: KnowledgeBase): boolean {
 }
 
 /**
- * Custom input for the `knowledgeBaseIds` field. Instead of typing knowledge
- * base ids by hand, the editor picks from the org's knowledge bases (fetched
- * from Atlas). The field stores the selected ids; everything else (slug, name,
- * description) is resolved at runtime by context-mcp.
+ * Custom input for the `knowledgeBases` field. Instead of typing knowledge
+ * base slugs by hand, the editor picks from the org's knowledge bases (fetched
+ * from Atlas). The field stores the selected slugs; everything else (name,
+ * description) is resolved at runtime by context-mcp, which addresses Atlas by
+ * slug.
  */
 export function KnowledgeBaseInput(props: ArrayOfPrimitivesInputProps) {
   const {onChange} = props
@@ -30,8 +31,8 @@ export function KnowledgeBaseInput(props: ArrayOfPrimitivesInputProps) {
   const {knowledgeBases, loading, error, retry} = useKnowledgeBases()
 
   const toggle = useCallback(
-    (id: string, checked: boolean) => {
-      const next = checked ? [...selected, id] : selected.filter((x) => x !== id)
+    (slug: string, checked: boolean) => {
+      const next = checked ? [...selected, slug] : selected.filter((x) => x !== slug)
       onChange(next.length > 0 ? set(next) : unset())
     },
     [onChange, selected],
@@ -93,7 +94,7 @@ export function KnowledgeBaseInput(props: ArrayOfPrimitivesInputProps) {
         <KnowledgeBaseRow
           key={kb.id}
           knowledgeBase={kb}
-          checked={selected.includes(kb.id)}
+          checked={selected.includes(kb.slug)}
           onToggle={toggle}
         />
       ))}
@@ -108,7 +109,7 @@ function KnowledgeBaseRow({
 }: {
   knowledgeBase: KnowledgeBase
   checked: boolean
-  onToggle: (id: string, checked: boolean) => void
+  onToggle: (slug: string, checked: boolean) => void
 }) {
   const disabled = !isSelectable(kb)
 
@@ -126,7 +127,7 @@ function KnowledgeBaseRow({
           <Checkbox
             checked={checked}
             disabled={disabled}
-            onChange={(e) => onToggle(kb.id, e.currentTarget.checked)}
+            onChange={(e) => onToggle(kb.slug, e.currentTarget.checked)}
           />
 
           <Text size={1} weight="medium">

--- a/packages/context/src/studio/context-document/knowledge-base-input/atlas.test.ts
+++ b/packages/context/src/studio/context-document/knowledge-base-input/atlas.test.ts
@@ -1,0 +1,80 @@
+import {describe, expect, it, vi} from 'vitest'
+
+import {
+  fetchKnowledgeBases,
+  fetchKnowledgeBasesForProject,
+  fetchProjectOrganizationId,
+  type RequestClient,
+  type RequestOptions,
+} from './atlas'
+
+/**
+ * A fake client that records requested URLs and returns queued responses. The
+ * paths must be VERSION-LESS and on no project hostname — the real client
+ * prepends `https://api.sanity.work/vX`. These tests pin that contract, since a
+ * doubled version (`/vX/vX`) or a project-host prefix is what broke the picker.
+ */
+function fakeClient(responses: unknown[]): {client: RequestClient; urls: string[]} {
+  const urls: string[] = []
+  let i = 0
+  const client: RequestClient = {
+    request: vi.fn(async (options: RequestOptions) => {
+      urls.push(options.url)
+      return responses[i++] as never
+    }),
+  }
+  return {client, urls}
+}
+
+describe('fetchProjectOrganizationId', () => {
+  it('requests the version-less /projects/{id} path and returns the org id', async () => {
+    const {client, urls} = fakeClient([{organizationId: 'oWjsciicj'}])
+    const org = await fetchProjectOrganizationId(client, 'm6urx9qg')
+    expect(org).toBe('oWjsciicj')
+    expect(urls).toEqual(['/projects/m6urx9qg'])
+  })
+
+  it('returns null when the project has no organization', async () => {
+    const {client} = fakeClient([{organizationId: null}])
+    expect(await fetchProjectOrganizationId(client, 'p')).toBeNull()
+  })
+})
+
+describe('fetchKnowledgeBases', () => {
+  it('requests the version-less, org-scoped, non-project-host path', async () => {
+    const {client, urls} = fakeClient([{data: [{id: '1', slug: 's', name: 'N'}]}])
+    await fetchKnowledgeBases(client, 'oWjsciicj')
+    expect(urls).toEqual(['/context/organizations/oWjsciicj/knowledge-bases'])
+    // Guard against the original bug: no version in the path, no project host.
+    expect(urls[0]).not.toContain('/vX/')
+    expect(urls[0]).not.toContain('.api.sanity')
+  })
+
+  it('follows nextCursor across pages and concatenates results', async () => {
+    const {client, urls} = fakeClient([
+      {data: [{id: '1', slug: 'a', name: 'A'}], nextCursor: 'CUR'},
+      {data: [{id: '2', slug: 'b', name: 'B'}]},
+    ])
+    const result = await fetchKnowledgeBases(client, 'org')
+    expect(result.map((k) => k.id)).toEqual(['1', '2'])
+    expect(urls[1]).toContain('nextCursor=CUR')
+  })
+})
+
+describe('fetchKnowledgeBasesForProject', () => {
+  it('resolves the org from the project, then lists its knowledge bases', async () => {
+    const {client, urls} = fakeClient([
+      {organizationId: 'org-x'},
+      {data: [{id: '1', slug: 'a', name: 'A'}]},
+    ])
+    const result = await fetchKnowledgeBasesForProject(client, 'proj-1')
+    expect(result).toHaveLength(1)
+    expect(urls).toEqual(['/projects/proj-1', '/context/organizations/org-x/knowledge-bases'])
+  })
+
+  it('returns [] without listing when the project has no org', async () => {
+    const {client, urls} = fakeClient([{organizationId: null}])
+    expect(await fetchKnowledgeBasesForProject(client, 'p')).toEqual([])
+    expect(urls).toEqual(['/projects/p']) // never reached the list endpoint
+  })
+})

--- a/packages/context/src/studio/context-document/knowledge-base-input/atlas.ts
+++ b/packages/context/src/studio/context-document/knowledge-base-input/atlas.ts
@@ -1,0 +1,100 @@
+/**
+ * Atlas (Sanity Context) knowledge-base API helpers, for the Studio picker.
+ *
+ * The knowledge-base endpoints are org-scoped and live on the same host as the
+ * data API (`{apiHost}/vX/context/...`). Studio only knows the projectId, so we
+ * first resolve the organizationId from the projects API, then list the org's
+ * knowledge bases.
+ *
+ * These take a minimal client surface so they can be unit-tested without a real
+ * Sanity client.
+ */
+
+/** A knowledge base as returned by the Atlas list endpoint. */
+export interface KnowledgeBase {
+  id: string
+  slug: string
+  name: string
+  description?: string
+  /** 'ready' knowledge bases are usable; others are still building/created. */
+  state?: string
+}
+
+/** Options passed through to the underlying client request. */
+export interface RequestOptions {
+  url: string
+  method?: string
+  /** Cap retries so a hard failure (e.g. CORS) doesn't loop. */
+  maxRetries?: number
+  retryDelay?: (attemptNumber: number) => number
+}
+
+/** Minimal client surface: a `request` that hits an absolute API path. */
+export interface RequestClient {
+  request<T>(options: RequestOptions): Promise<T>
+}
+
+/**
+ * Bounded retry policy shared by the knowledge-base requests: at most 2 retries
+ * with a short exponential backoff (300ms, 600ms), capped. Prevents the client's
+ * default retry behavior from hammering an endpoint that's hard-failing.
+ */
+export const KB_RETRY = {
+  maxRetries: 2,
+  retryDelay: (attemptNumber: number) => Math.min(300 * 2 ** attemptNumber, 2000),
+}
+
+/**
+ * Resolve the organizationId that owns a project. Mirrors context-mcp's
+ * `fetchProjectOrganizationId`. Returns null when the project has no org.
+ */
+export async function fetchProjectOrganizationId(
+  client: RequestClient,
+  projectId: string,
+): Promise<string | null> {
+  const project = await client.request<{organizationId?: string | null}>({
+    url: `/projects/${projectId}`,
+    ...KB_RETRY,
+  })
+  return project?.organizationId ?? null
+}
+
+/**
+ * List the knowledge bases for an organization. The endpoint is cursor-paginated;
+ * we follow `nextCursor` so all knowledge bases are returned.
+ */
+export async function fetchKnowledgeBases(
+  client: RequestClient,
+  organizationId: string,
+): Promise<KnowledgeBase[]> {
+  // Version-less path — the configured client prepends the API version (`/vX`)
+  // and the bare host (no project hostname), giving
+  // `https://api.sanity.work/vX/context/organizations/{org}/knowledge-bases`.
+  const base = `/context/organizations/${organizationId}/knowledge-bases`
+  const all: KnowledgeBase[] = []
+  let cursor: string | undefined
+
+  // Bound the loop defensively; real orgs have far fewer pages.
+  for (let page = 0; page < 50; page++) {
+    const url = cursor ? `${base}?nextCursor=${encodeURIComponent(cursor)}` : base
+    const res = await client.request<{data?: KnowledgeBase[]; nextCursor?: string | null}>({
+      url,
+      ...KB_RETRY,
+    })
+    if (res?.data?.length) all.push(...res.data)
+    cursor = res?.nextCursor ?? undefined
+    if (!cursor) break
+  }
+
+  return all
+}
+
+/** Resolve the org from the project, then list its knowledge bases. */
+export async function fetchKnowledgeBasesForProject(
+  client: RequestClient,
+  projectId: string,
+): Promise<KnowledgeBase[]> {
+  const organizationId = await fetchProjectOrganizationId(client, projectId)
+  if (!organizationId) return []
+  return fetchKnowledgeBases(client, organizationId)
+}

--- a/packages/context/src/studio/context-document/knowledge-base-input/useKnowledgeBases.ts
+++ b/packages/context/src/studio/context-document/knowledge-base-input/useKnowledgeBases.ts
@@ -1,0 +1,81 @@
+import {useCallback, useMemo} from 'react'
+import {useObservable} from 'react-rx'
+import {firstValueFrom, of, Subject} from 'rxjs'
+import {catchError, map, startWith, switchMap} from 'rxjs/operators'
+import {DEFAULT_STUDIO_CLIENT_OPTIONS, useClient, useProjectId} from 'sanity'
+
+import {fetchKnowledgeBasesForProject, type KnowledgeBase, type RequestClient} from './atlas'
+
+export interface KnowledgeBasesState {
+  knowledgeBases: KnowledgeBase[]
+  loading: boolean
+  error: string | null
+  retry: () => void
+}
+
+const INITIAL: KnowledgeBasesState = {
+  knowledgeBases: [],
+  loading: true,
+  error: null,
+  retry: () => {},
+}
+
+/**
+ * Fetch the current project's knowledge bases from Atlas. Resolves the org from
+ * the projectId, then lists its knowledge bases, exposing loading/error/retry —
+ * the same shape the insights dashboard uses for its data hooks.
+ */
+export function useKnowledgeBases(): KnowledgeBasesState {
+  const studioClient = useClient(DEFAULT_STUDIO_CLIENT_OPTIONS)
+  const projectId = useProjectId()
+
+  const retry$ = useMemo(() => new Subject<void>(), [])
+  const retry = useCallback(() => retry$.next(), [retry$])
+
+  const state$ = useMemo(() => {
+    // The Atlas / Context endpoints are GLOBAL (org-scoped), served from the
+    // bare API host — not the project hostname the Studio client uses by
+    // default. With project hostnames on, the client builds
+    // `https://<projectId>.api.sanity.work/<version>/...`, which 404s/CORS-fails.
+    // Reconfigure to hit the bare host with apiVersion `vX`; the atlas helpers
+    // then pass version-less paths (`/context/...`) and the client prepends
+    // `https://api.sanity.work/vX`.
+    const client = studioClient.withConfig({
+      useProjectHostname: false,
+      apiVersion: 'vX',
+    })
+
+    const requestClient: RequestClient = {
+      request: (options) => firstValueFrom(client.observable.request(options)),
+    }
+
+    const load = () =>
+      of(null).pipe(
+        switchMap(() => fetchKnowledgeBasesForProject(requestClient, projectId)),
+        map(
+          (knowledgeBases): KnowledgeBasesState => ({
+            knowledgeBases,
+            loading: false,
+            error: null,
+            retry,
+          }),
+        ),
+        catchError((err: unknown) =>
+          of<KnowledgeBasesState>({
+            knowledgeBases: [],
+            loading: false,
+            error: err instanceof Error ? err.message : String(err),
+            retry,
+          }),
+        ),
+        startWith({...INITIAL, retry}),
+      )
+
+    return retry$.pipe(
+      startWith(undefined),
+      switchMap(() => load()),
+    )
+  }, [studioClient, projectId, retry, retry$])
+
+  return useObservable(state$, {...INITIAL, retry})
+}


### PR DESCRIPTION
### Description

Adds knowledge-base support to the `sanity.agentContext` (Sanity Context)
document. Editors can attach one or more knowledge bases to a Context and
control whether agents may also query content directly with GROQ. The document
stores only knowledge-base **ids**; their slug/name/description are resolved at
runtime by the consumer (context-mcp), so nothing goes stale.

## Schema

Two new fields on `contextSchema`:

- **`knowledgeBaseIds`** (`array<string>`) — the attached knowledge bases.
  Rendered by a custom picker (below) rather than free text.
- **`groqEnabled`** (`boolean`, defaults `true`) — let agents query all content
  directly.

The GROQ toggle and the existing **Content filter** are grouped into one
collapsible **"Direct content access"** fieldset, so the relationship is
explicit. The fields stay top-level in the document (fieldsets are visual only),
so consumers read `groqEnabled` / `groqFilter` unchanged — no data migration.

The content filter is now shown **read-only** (greyed in place) when querying is
off, instead of being hidden — this removes the layout jump the previous
`hidden` behaviour caused.

## Knowledge-base picker

A custom input (`KnowledgeBaseInput`) for the `knowledgeBaseIds` field:

- Resolves the `organizationId` from the project, then fetches the org's
  knowledge bases from the Sanity Context (Atlas) API
  (`{apiHost}/vX/context/organizations/{org}/knowledge-bases`).
- Multi-select by name + description; knowledge bases that aren't yet built
  (state other than `ready` / `review`) are shown disabled.
- Loading / error (with retry) / empty states.
- Stores the selected **ids** only.

Data fetching (`atlas.ts`, `useKnowledgeBases.ts`) follows the rxjs/`useObservable`
pattern already used by the Insights dashboard. The Context API endpoints are
global (not project-hostname routed), so the client is reconfigured with
`useProjectHostname: false` + `apiVersion: 'vX'` and given version-less paths —
otherwise the request resolves to a doubled-version, project-host URL that
CORS-fails.

## GroqFilterInput

Threaded `readOnly` through the existing content-filter input so that when
direct querying is off, the filter is genuinely inert (type chips can't be
removed, search/add controls disabled, GROQ textarea read-only), not just
visually greyed.

## Tests

- `contextSchema.test.ts` — the two new fields (types, defaults).
- `atlas.test.ts` — URL construction (version-less, org-scoped, no project
  host — guards the CORS regression), cursor pagination, org resolution.

## Notes

- The document is the single source of truth for what tools an agent gets; the
  consumer (context-mcp) resolves ids → knowledge-base tools. See the companion
  context-mcp PR.
- Attaching is allowed for `ready` and `review` knowledge bases; only unbuilt
  states are blocked.
  
  
<img width="795" height="811" alt="image" src="https://github.com/user-attachments/assets/69bca77e-42ac-421e-ab4e-5d7ca0935509" />
