### PR TITLE
feat: add initial-context in system prompt

### DIFF
--- a/examples/ecommerce/app/src/app/api/chat/route.ts
+++ b/examples/ecommerce/app/src/app/api/chat/route.ts
@@ -16,20 +16,55 @@ import {writeClient} from '@/sanity/lib/write-client'
 const DEFAULT_MODEL = 'claude-sonnet-4-5'
 const MAX_STEPS = 20
 
+let cachedInitialContext: string | null = null
+let cacheTimestamp = 0
+const CACHE_TTL_MS = 5 * 60 * 1000
+
+function initialContextUrl(mcpUrl: string): string {
+  const url = new URL(mcpUrl)
+  url.pathname = `${url.pathname.replace(/\/$/, '')}/initial-context`
+  return url.toString()
+}
+
+// Slow on cold start — subsequent calls return the cached result
+async function fetchInitialContext(): Promise<string | null> {
+  const mcpUrl = process.env.SANITY_CONTEXT_MCP_URL
+  if (!mcpUrl) return null
+
+  const isStale = Date.now() - cacheTimestamp > CACHE_TTL_MS
+  const fetchPromise = isStale
+    ? fetch(initialContextUrl(mcpUrl), {
+        headers: {Authorization: `Bearer ${process.env.SANITY_API_READ_TOKEN}`},
+      })
+        .then(async (res) => {
+          if (res.ok) {
+            cachedInitialContext = await res.text()
+            cacheTimestamp = Date.now()
+          }
+        })
+        .catch(() => {})
+    : null
+
+  if (!cachedInitialContext) await fetchPromise
+
+  return cachedInitialContext
+}
+
 interface BuildSystemPromptParams {
   basePrompt: string
   documentContext: DocumentContext
+  initialContext?: string | null
 }
 
 /**
  * Combines base prompt from Sanity with page context and tool instructions.
  */
 function buildSystemPrompt(props: BuildSystemPromptParams): string {
-  const {basePrompt, documentContext} = props
+  const {basePrompt, documentContext, initialContext} = props
 
   return `
 ${basePrompt}
-
+${initialContext ? `\n# Content context\n\n${initialContext}\n` : ''}
 # Current page
 
 <page-context>
@@ -95,8 +130,7 @@ export async function POST(req: Request) {
   let mcpClient: MCPClient | null = null
 
   try {
-    // Initialize MCP client and fetch system prompt from Sanity document
-    const [mcpClientResult, agentConfig] = await Promise.all([
+    const [mcpClientResult, agentConfig, initialContext] = await Promise.all([
       createMCPClient({
         transport: {
           type: 'http',
@@ -110,6 +144,7 @@ export async function POST(req: Request) {
         `*[_type == "agent.config" && slug.current == $slug][0] { systemPrompt }`,
         {slug: process.env.AGENT_CONFIG_SLUG || 'default'},
       ),
+      fetchInitialContext(),
     ])
 
     mcpClient = mcpClientResult
@@ -125,9 +160,14 @@ export async function POST(req: Request) {
     const systemPrompt = buildSystemPrompt({
       basePrompt: agentConfig.systemPrompt,
       documentContext,
+      initialContext,
     })
 
-    const mcpTools = await mcpClient.tools()
+    const allMcpTools = await mcpClient.tools()
+
+    // Exclude initial_context tool, its data is already in the system prompt
+    const {initial_context: _, ...mcpTools} = allMcpTools
+
     const modelId = process.env.ANTHROPIC_MODEL || DEFAULT_MODEL
 
     const result = streamText({

--- a/examples/ecommerce/app/src/app/api/chat/route.ts
+++ b/examples/ecommerce/app/src/app/api/chat/route.ts
@@ -64,7 +64,7 @@ function buildSystemPrompt(props: BuildSystemPromptParams): string {
 
   return `
 ${basePrompt}
-${initialContext ? `\n# Content context\n\n${initialContext}\n` : ''}
+${initialContext ? `\n# Data reference\n\nUse this to understand what's available and write better queries.\n\n${initialContext}\n` : ''}
 # Current page
 
 <page-context>

--- a/skills/create-agent-with-sanity-context/SKILL.md
+++ b/skills/create-agent-with-sanity-context/SKILL.md
@@ -37,10 +37,11 @@ Before starting, gather these credentials:
 
 The Sanity Context MCP server gives AI agents structured access to Sanity content. The core integration pattern:
 
-1. **MCP Connection**: HTTP transport to the Sanity Context URL
-2. **Authentication**: Bearer token using Sanity API read token
-3. **Tool Discovery**: Get available tools from MCP client, pass to LLM
-4. **System Prompt**: Tell the production agent its role, tone, and boundaries
+1. **Initial Context**: Fetch schema context via the `/initial-context` HTTP endpoint and inject it into the system prompt
+2. **MCP Connection**: HTTP transport to the Sanity Context URL
+3. **Authentication**: Bearer token using Sanity API read token
+4. **Tool Discovery**: Get available tools from MCP client, pass to LLM
+5. **System Prompt**: Tell the production agent its role, tone, and boundaries
 
 **MCP URL formats:**
 
@@ -64,13 +65,28 @@ This means Studio users can manage agent behavior without touching code — upda
 
 **The integration is simple**: Connect to the MCP URL, get tools, use them. The reference implementation shows one way to do this—adapt to your stack and LLM provider.
 
+**Initial context (recommended):**
+
+Always fetch the schema context via the `/initial-context` HTTP endpoint and inject it into the system prompt. This gives a significant latency improvement on the first message—the agent already knows the schema and available tools without needing a tool call. It also enables better prompt caching since the schema prefix is stable across conversations.
+
+Append `/initial-context` to the MCP URL path (before any query params), using the same auth header:
+
+```bash
+curl https://api.sanity.io/v2026-03-03/context/mcp/:projectId/:dataset/:slug/initial-context \
+  -H "Authorization: Bearer $SANITY_API_READ_TOKEN"
+```
+
+Fetch once, cache the result, and include it in your system prompt. When using this, exclude the `initial_context` tool from the tools passed to the LLM to avoid redundant calls.
+
+If you don't control the system prompt (e.g. using a third-party MCP client), the `initial_context` MCP tool still works — the agent will call it on the first message instead.
+
 ## Available MCP Tools
 
-| Tool              | Purpose                                                         |
-| ----------------- | --------------------------------------------------------------- |
-| `initial_context` | Get compressed schema overview (types, fields, document counts) |
-| `groq_query`      | Execute GROQ queries with optional semantic search              |
-| `schema_explorer` | Get detailed schema for a specific document type                |
+| Tool              | Purpose                                                                                                                   |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `initial_context` | Get compressed schema overview (types, fields, document counts). Also available via the `/initial-context` HTTP endpoint. |
+| `groq_query`      | Execute GROQ queries with optional semantic search                                                                        |
+| `schema_explorer` | Get detailed schema for a specific document type                                                                          |
 
 **For development and debugging:** The general Sanity MCP provides broader access to your Sanity project (schema deployment, document management, etc.). Useful during development but not intended for customer-facing applications.
 

--- a/skills/create-agent-with-sanity-context/references/adapting-to-stacks.md
+++ b/skills/create-agent-with-sanity-context/references/adapting-to-stacks.md
@@ -16,13 +16,35 @@ The MCP connection pattern is framework and LLM-agnostic. This guide shows how t
 Regardless of framework, the integration follows this flow:
 
 ```
-1. Create MCP client with HTTP transport
-2. Authenticate with Sanity API token
-3. Get tools from MCP client
-4. Pass tools to your LLM along with system prompt
-5. Handle tool calls and responses
-6. Clean up MCP connection when done
+1. Fetch initial context via HTTP (${MCP_URL}/initial-context) — cache the result
+2. Create MCP client with HTTP transport
+3. Authenticate with Sanity API token
+4. Get tools from MCP client
+5. Build system prompt with initial context injected
+6. Pass tools to your LLM along with system prompt
+7. Handle tool calls and responses
+8. Clean up MCP connection when done
 ```
+
+---
+
+## Initial Context via HTTP
+
+Append `/initial-context` to the MCP URL **path** (before any query params) to fetch the schema context as plain HTTP. Same auth header, same query params. Cache the result and inject it into your system prompt:
+
+```ts
+const url = new URL(MCP_URL)
+url.pathname = `${url.pathname.replace(/\/$/, '')}/initial-context`
+
+const response = await fetch(url, {
+  headers: { Authorization: `Bearer ${API_TOKEN}` },
+})
+const initialContext = await response.text()
+
+const systemPrompt = `${BASE_PROMPT}\n\n# Content context\n\n${initialContext}`
+```
+
+This eliminates the `initial_context` tool call on every first message and enables prompt caching (the schema prefix is stable across conversations).
 
 ---
 
@@ -32,15 +54,18 @@ Regardless of framework, the integration follows this flow:
 
 ```ts
 app.post('/api/chat', async (req, res) => {
-  const mcpClient = await createMCPClient({
-    transport: {
-      type: 'http',
-      url: process.env.SANITY_CONTEXT_MCP_URL,
-      headers: {Authorization: `Bearer ${process.env.SANITY_API_READ_TOKEN}`},
-    },
-  })
+  const [mcpClient, initialContext] = await Promise.all([
+    createMCPClient({
+      transport: {
+        type: 'http',
+        url: process.env.SANITY_CONTEXT_MCP_URL,
+        headers: {Authorization: `Bearer ${process.env.SANITY_API_READ_TOKEN}`},
+      },
+    }),
+    fetchInitialContext(), // See "Initial Context via HTTP" above
+  ])
   const tools = await mcpClient.tools()
-  // Pass tools to your LLM, handle response...
+  // Include initialContext in system prompt, pass tools to LLM...
 })
 ```
 
@@ -63,7 +88,20 @@ export async function action({request}: ActionFunctionArgs) {
 **Python/FastAPI**
 
 ```python
+import httpx
 from mcp import Client, HttpTransport
+
+# Fetch initial context via HTTP
+async def fetch_initial_context() -> str:
+    from urllib.parse import urlparse, urlunparse
+    parsed = urlparse(os.environ["SANITY_CONTEXT_MCP_URL"])
+    url = urlunparse(parsed._replace(path=parsed.path.rstrip("/") + "/initial-context"))
+    async with httpx.AsyncClient() as http:
+        resp = await http.get(
+            url,
+            headers={"Authorization": f"Bearer {os.environ['SANITY_API_READ_TOKEN']}"},
+        )
+        return resp.text
 
 client = Client(
     transport=HttpTransport(
@@ -71,8 +109,8 @@ client = Client(
         headers={"Authorization": f"Bearer {os.environ['SANITY_API_READ_TOKEN']}"}
     )
 )
-tools = await client.get_tools()
-# Pass tools to your LLM, handle response...
+initial_context, tools = await fetch_initial_context(), await client.get_tools()
+# Include initial_context in system prompt, pass tools to LLM...
 ```
 
 ---

--- a/skills/create-agent-with-sanity-context/references/nextjs-agent.md
+++ b/skills/create-agent-with-sanity-context/references/nextjs-agent.md
@@ -78,16 +78,38 @@ const mcpClient = await createMCPClient({
 })
 ```
 
+**Initial Context via HTTP:**
+
+Always fetch the schema context at startup and inject it into the system prompt. This gives a significant latency improvement—the agent already knows the schema without a tool call on the first message—and enables better prompt caching.
+
+See [ecommerce/app/src/app/api/chat/route.ts](ecommerce/app/src/app/api/chat/route.ts) for the full implementation, including caching and URL construction that handles query params correctly.
+
+Add it to the `Promise.all` alongside the MCP client and agent config:
+
+```ts
+const [mcpClientResult, agentConfig, initialContext] = await Promise.all([
+  createMCPClient({ /* ... */ }),
+  client.fetch(/* ... */),
+  fetchInitialContext(),
+])
+```
+
+Include the result in your system prompt—see [ecommerce/app/src/app/api/chat/route.ts](ecommerce/app/src/app/api/chat/route.ts) for the `buildSystemPrompt` pattern.
+
 **Tool Combination** (`streamText`):
 
 ```ts
-const mcpTools = await mcpClient.tools()
+const allMcpTools = await mcpClient.tools()
+
+// Exclude initial_context tool — its data is already in the system prompt
+const {initial_context: _, ...mcpTools} = allMcpTools
+
 const result = streamText({
   model: anthropic('claude-opus-4-5'),
   system: systemPrompt,
   messages: await convertToModelMessages(messages),
   tools: {
-    ...mcpTools, // Sanity Context tools (groq_query, initial_context, etc.)
+    ...mcpTools, // Sanity Context tools (groq_query, schema_explorer, etc.)
     ...clientTools, // Client-side tools (page context, screenshot)
   },
 })
@@ -140,8 +162,8 @@ curl -X POST http://localhost:3000/api/chat \
 
 The agent should:
 
-1. Call `initial_context` to understand available content types
-2. Respond with a summary of what it can help with
+1. Already know the available content types (schema context is in the system prompt via `/initial-context`)
+2. Respond with a summary of what it can help with—no tool call needed on the first message
 
 ---
 

--- a/skills/create-agent-with-sanity-context/references/sveltekit-agent.md
+++ b/skills/create-agent-with-sanity-context/references/sveltekit-agent.md
@@ -311,6 +311,23 @@ export const ssr = false
 </style>
 ```
 
+**Initial Context via HTTP:**
+
+Always fetch the schema context at startup and inject it into the system prompt. Append `/initial-context` to the MCP URL path (before any query params) and fetch with the same auth header. Cache the result. See [ecommerce/app/src/app/api/chat/route.ts](ecommerce/app/src/app/api/chat/route.ts) for a full implementation with caching.
+
+```ts
+const [mcpClient, initialContext] = await Promise.all([
+  createMCPClient({ /* ... */ }),
+  fetchInitialContext(),
+])
+
+const mcpTools = await mcpClient.tools()
+
+const systemPrompt = initialContext
+  ? `${SYSTEM_PROMPT}\n\n# Content context\n\n${initialContext}`
+  : SYSTEM_PROMPT
+```
+
 **Key patterns:**
 
 - **`Chat` class** — Svelte uses a class instantiation (`new Chat({...})`) instead of React's `useChat` hook
@@ -336,8 +353,8 @@ curl -X POST http://localhost:5173/api/chat \
 
 The agent should:
 
-1. Call `groq_query` or `schema_explorer` to understand available content types
-2. Respond with a summary of what it can help with
+1. Already know the available content types (schema context is in the system prompt via `/initial-context`)
+2. Respond with a summary of what it can help with—no tool call needed on the first message
 
 ---
 


### PR DESCRIPTION
### Description

Disabled to `initial-context` tool and puts its results in the system prompt instead, shaving ~3-6 seconds off the first message latency.

There is a 5 minute TTL in-memory cache to reduce calls. Slightly stale data is considered fine to serve.

Skill is updated with info on how to use this endpoint and handle initial context in system prompt.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->
