### PR TITLE
feat: update @sanity/icons to v5.0.0 and update icon import paths

### DIFF
--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -86,7 +86,7 @@
   "peerDependencies": {
     "@sanity/client": "^7",
     "@sanity/color": "^3",
-    "@sanity/icons": "^3",
+    "@sanity/icons": "^5",
     "@sanity/ui": "^3",
     "ai": "^6.0.175",
     "react": "^19",

--- a/packages/context/src/studio/context-document/context-document-input/ContextDocumentInput.tsx
+++ b/packages/context/src/studio/context-document/context-document-input/ContextDocumentInput.tsx
@@ -1,4 +1,4 @@
-import {CopyIcon} from '@sanity/icons'
+import {CopyIcon} from '@sanity/icons/Copy'
 import {Box, Button, Card, Flex, Stack, Text, Tooltip, useToast} from '@sanity/ui'
 import {useCallback} from 'react'
 import {

--- a/packages/context/src/studio/context-document/contextSchema.ts
+++ b/packages/context/src/studio/context-document/contextSchema.ts
@@ -1,4 +1,4 @@
-import {DatabaseIcon} from '@sanity/icons'
+import {DatabaseIcon} from '@sanity/icons/Database'
 import {defineField, defineType} from 'sanity'
 
 import {ContextDocumentInput} from './context-document-input/ContextDocumentInput'

--- a/packages/context/src/studio/context-document/groq-filter-input/GroqFilterInput.tsx
+++ b/packages/context/src/studio/context-document/groq-filter-input/GroqFilterInput.tsx
@@ -1,11 +1,9 @@
-import {
-  CheckmarkIcon,
-  ChevronDownIcon,
-  CloseIcon,
-  ErrorOutlineIcon,
-  GroqIcon,
-  ListIcon,
-} from '@sanity/icons'
+import {CheckmarkIcon} from '@sanity/icons/Checkmark'
+import {ChevronDownIcon} from '@sanity/icons/ChevronDown'
+import {CloseIcon} from '@sanity/icons/Close'
+import {ErrorOutlineIcon} from '@sanity/icons/ErrorOutline'
+import {GroqIcon} from '@sanity/icons/Groq'
+import {ListIcon} from '@sanity/icons/List'
 import {
   Box,
   Button,

--- a/packages/context/src/studio/insights/dashboard/ErrorBlock.tsx
+++ b/packages/context/src/studio/insights/dashboard/ErrorBlock.tsx
@@ -1,4 +1,4 @@
-import {RetryIcon} from '@sanity/icons'
+import {RetryIcon} from '@sanity/icons/Retry'
 import {Button, Card, Container, Flex, Stack, Text} from '@sanity/ui'
 
 interface ErrorBlockProps {

--- a/packages/context/src/studio/insights/dashboard/InsightsDashboard.tsx
+++ b/packages/context/src/studio/insights/dashboard/InsightsDashboard.tsx
@@ -1,4 +1,7 @@
-import {CheckmarkIcon, ChevronDownIcon, CommentIcon, DashboardIcon} from '@sanity/icons'
+import {CheckmarkIcon} from '@sanity/icons/Checkmark'
+import {ChevronDownIcon} from '@sanity/icons/ChevronDown'
+import {CommentIcon} from '@sanity/icons/Comment'
+import {DashboardIcon} from '@sanity/icons/Dashboard'
 import {Box, Button, Card, Flex, Menu, MenuButton, MenuDivider, MenuItem, Stack} from '@sanity/ui'
 import {Activity, useId, useState} from 'react'
 import {useRouter} from 'sanity/router'

--- a/packages/context/src/studio/insights/dashboard/Table.tsx
+++ b/packages/context/src/studio/insights/dashboard/Table.tsx
@@ -1,4 +1,5 @@
-import {ArrowDownIcon, ArrowUpIcon} from '@sanity/icons'
+import {ArrowDownIcon} from '@sanity/icons/ArrowDown'
+import {ArrowUpIcon} from '@sanity/icons/ArrowUp'
 import {Box, Button, Flex, Text} from '@sanity/ui'
 import {styled} from 'styled-components'
 

--- a/packages/context/src/studio/insights/dashboard/TextWithInfo.tsx
+++ b/packages/context/src/studio/insights/dashboard/TextWithInfo.tsx
@@ -1,4 +1,4 @@
-import {InfoOutlineIcon} from '@sanity/icons'
+import {InfoOutlineIcon} from '@sanity/icons/InfoOutline'
 import {Box, Flex, Text, type TextProps, Tooltip} from '@sanity/ui'
 import type React from 'react'
 

--- a/packages/context/src/studio/insights/dashboard/conversations/ConversationDetail.tsx
+++ b/packages/context/src/studio/insights/dashboard/conversations/ConversationDetail.tsx
@@ -1,4 +1,4 @@
-import {CloseIcon} from '@sanity/icons'
+import {CloseIcon} from '@sanity/icons/Close'
 import {Badge, Box, Button, Card, Container, Flex, Grid, Label, Stack, Text} from '@sanity/ui'
 import type {ReactNode} from 'react'
 

--- a/packages/context/src/studio/insights/dashboard/conversations/ConversationList.tsx
+++ b/packages/context/src/studio/insights/dashboard/conversations/ConversationList.tsx
@@ -1,4 +1,5 @@
-import {FilterIcon, SearchIcon} from '@sanity/icons'
+import {FilterIcon} from '@sanity/icons/Filter'
+import {SearchIcon} from '@sanity/icons/Search'
 import {
   Badge,
   Box,

--- a/packages/context/src/studio/insights/dashboard/conversations/ConversationMessage.tsx
+++ b/packages/context/src/studio/insights/dashboard/conversations/ConversationMessage.tsx
@@ -1,4 +1,7 @@
-import {ChevronDownIcon, RobotIcon, UserIcon, WrenchIcon} from '@sanity/icons'
+import {ChevronDownIcon} from '@sanity/icons/ChevronDown'
+import {RobotIcon} from '@sanity/icons/Robot'
+import {UserIcon} from '@sanity/icons/User'
+import {WrenchIcon} from '@sanity/icons/Wrench'
 import {Box, Card, type CardTone, Code, Flex, Text} from '@sanity/ui'
 import {useMemo, useState} from 'react'
 

--- a/packages/context/src/studio/insights/dashboard/conversations/FilterMenu.tsx
+++ b/packages/context/src/studio/insights/dashboard/conversations/FilterMenu.tsx
@@ -1,4 +1,5 @@
-import {CheckmarkIcon, ChevronDownIcon} from '@sanity/icons'
+import {CheckmarkIcon} from '@sanity/icons/Checkmark'
+import {ChevronDownIcon} from '@sanity/icons/ChevronDown'
 import {Button, Menu, MenuButton, MenuDivider, MenuItem} from '@sanity/ui'
 import {useId} from 'react'
 

--- a/packages/context/src/studio/insights/dashboard/overview/ContentGapRow.tsx
+++ b/packages/context/src/studio/insights/dashboard/overview/ContentGapRow.tsx
@@ -1,4 +1,4 @@
-import {ChevronRightIcon} from '@sanity/icons'
+import {ChevronRightIcon} from '@sanity/icons/ChevronRight'
 import {Box, Card, Flex, Text} from '@sanity/ui'
 
 interface ContentGapRowProps {

--- a/packages/context/src/studio/plugin.ts
+++ b/packages/context/src/studio/plugin.ts
@@ -1,4 +1,4 @@
-import {ChartUpwardIcon} from '@sanity/icons'
+import {ChartUpwardIcon} from '@sanity/icons/ChartUpward'
 import {definePlugin} from 'sanity'
 import {route} from 'sanity/router'
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,8 +13,8 @@ catalogs:
       specifier: ^3
       version: 3.0.6
     '@sanity/icons':
-      specifier: ^3
-      version: 3.7.4
+      specifier: ^5.0.0
+      version: 5.0.0
     '@sanity/ui':
       specifier: ^3
       version: 3.1.14
@@ -348,7 +348,7 @@ importers:
         version: 3.0.6
       '@sanity/icons':
         specifier: 'catalog:'
-        version: 3.7.4(react@19.2.5)
+        version: 5.0.0(react@19.2.5)
       '@sanity/pkg-utils':
         specifier: ^10.4.13
         version: 10.4.18(@types/babel__core@7.20.5)(@types/node@22.19.17)(babel-plugin-react-compiler@1.0.0)(typescript@5.9.3)
@@ -3589,6 +3589,12 @@ packages:
     engines: {node: '>=14.0.0'}
     peerDependencies:
       react: ^18.3 || ^19.0.0-0
+
+  '@sanity/icons@5.0.0':
+    resolution: {integrity: sha512-fINQLovVnCANwQbQ63iO2mUVh2ZX3T4h3hiSEaIStvladI5tmrGAuT+XbUuk3jTmBwOHDGD0EL9lpsghGAS+Sg==}
+    engines: {node: '>=22.12'}
+    peerDependencies:
+      react: ^19
 
   '@sanity/id-utils@1.0.0':
     resolution: {integrity: sha512-2sb7tbdMDuUuVyocJPKG0gZBiOML/ovCe+mJiLrv1j69ODOfa2LfUjDVR+dRw/A/+XuxoJSSP8ebG7NiwTOgIA==}
@@ -12170,6 +12176,10 @@ snapshots:
   '@sanity/generate-help-url@4.0.0': {}
 
   '@sanity/icons@3.7.4(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+
+  '@sanity/icons@5.0.0(react@19.2.5)':
     dependencies:
       react: 19.2.5
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,7 +7,7 @@ catalog:
   '@ai-sdk/anthropic': ^3.0.58
   '@sanity/client': ^7.21.0
   '@sanity/color': ^3
-  '@sanity/icons': ^3
+  '@sanity/icons': ^5.0.0
   '@sanity/ui': ^3
   '@sanity/vision': ^5.22.0
   '@types/react': ^19


### PR DESCRIPTION
### Description

This pull request upgrades the `@sanity/icons` package from version 3 to version 5 and updates all icon imports throughout the codebase to use the new explicit import paths required by the latest version. This change ensures compatibility with the updated icon package and improves tree-shaking and bundle size by importing only the icons in use.

**Dependency upgrade and import updates:**

* Upgraded `@sanity/icons` from version 3.7.4 to 5.0.0 in `pnpm-lock.yaml` and `pnpm-workspace.yaml`, and updated dependency snapshots to reflect the new version. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL16-R17) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL351-R351) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR3593-R3598) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR12182-R12185) [[5]](diffhunk://#diff-18ae0a0fab29a7db7aded913fd05f30a2c8f6c104fadae86c9d217091709794cL10-R10)

**Codebase-wide icon import changes:**

* Updated all icon imports to use the new explicit subpath imports required by `@sanity/icons@5` (e.g., `import {CopyIcon} from '@sanity/icons/Copy'` instead of `import {CopyIcon} from '@sanity/icons'`) in all relevant files within `packages/context/src/studio`. [[1]](diffhunk://#diff-9a55f3cade27cf8dac30f0332ac5bf72585519edcd2c45bbf882520e1aa24a23L1-R1) [[2]](diffhunk://#diff-d23381f064131c232f9292b91363f9099208030b08ad901b009e9b5de394856cL1-R1) [[3]](diffhunk://#diff-fec4c7d7cc5fd2393400cbedd3dee259587cac999bc754875d7c1682778f1e1aL1-R6) [[4]](diffhunk://#diff-96f4f1b5c64416e8748278465f8347c80c0e6cc24b37be9c509205b986e7ee98L1-R1) [[5]](diffhunk://#diff-8412595c2b8c7fd8fc7ccad39f92be2cc1c56ccae2b5a80d573ea0cb977dcc4eL1-R4) [[6]](diffhunk://#diff-a714f69e34d3b6cdd966134c07c4dec2cbc0f7db98c19b38eba0888aa9e85ba2L1-R2) [[7]](diffhunk://#diff-f0aefa374a7a5c574cf9d894f4a9fb8ae83df5d6ebef2f4dd5c74cffa60b6c2dL1-R1) [[8]](diffhunk://#diff-4e9d66572868e423b3a4287fbe048e4c7c7db30fa1e85ba75b0873745cf46ce8L1-R1) [[9]](diffhunk://#diff-22db8fe87a64d4072db150b715435da02344cfef92b51ccf4c76fec2a8f323dbL1-R2) [[10]](diffhunk://#diff-125ff6537a0ae877b5c88a419890837fd86d970379cb724724aa92fa6fd94b81L1-R4) [[11]](diffhunk://#diff-56712f41d635b42fd27876b65e2eb97737e144ce577e8d60f3d5f37af415f127L1-R2) [[12]](diffhunk://#diff-4f61eae24ec79b0fbc97876faa54a2520f074e7cf0a9d245c199d080cccefeddL1-R1) [[13]](diffhunk://#diff-337394d07a6edc9fc0d7a920bfbc3af5149ffe52bf1ee7b3d1a5f49a08c3605fL1-R1)

### What to review

Validate that the imports and dependency range for `@sanity/icons` in `pnpm-workspace.yaml` are correct.

### Testing

No new testing was added. Build, typecheck, lint, and tests pass.

### Related Issues

Closes #240 
